### PR TITLE
Split multicast read loop from discovery decision logic

### DIFF
--- a/src/discovery/announcement.go
+++ b/src/discovery/announcement.go
@@ -1,0 +1,34 @@
+package discovery
+
+import (
+	"net"
+	"strings"
+)
+
+// Announcement is a parsed discovery packet broadcast by another Node:
+// "NodeID|FullHash|APIAddr|LocalIP".
+type Announcement struct {
+	NodeID  string
+	Hash    string
+	APIAddr string
+	LocalIP string
+	Src     *net.UDPAddr
+}
+
+// ParseAnnouncement decodes a raw multicast packet. Returns (ann, true) when
+// the packet matches the four-field axial format, (zero, false) otherwise.
+// The function does no I/O and depends on nothing but its inputs, so the
+// parsing logic can be unit-tested without sockets.
+func ParseAnnouncement(packet string, src *net.UDPAddr) (Announcement, bool) {
+	parts := strings.Split(packet, "|")
+	if len(parts) != 4 {
+		return Announcement{}, false
+	}
+	return Announcement{
+		NodeID:  parts[0],
+		Hash:    parts[1],
+		APIAddr: parts[2],
+		LocalIP: parts[3],
+		Src:     src,
+	}, true
+}

--- a/src/discovery/announcement_test.go
+++ b/src/discovery/announcement_test.go
@@ -1,0 +1,57 @@
+package discovery
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseAnnouncement_HappyPath(t *testing.T) {
+	src := &net.UDPAddr{IP: net.ParseIP("192.168.1.42"), Port: 45678}
+	ann, ok := ParseAnnouncement("node-a|abc123|:8080|192.168.1.99", src)
+	if !ok {
+		t.Fatal("expected parse to succeed for a 4-field axial packet")
+	}
+	if ann.NodeID != "node-a" {
+		t.Errorf("NodeID: got %q want %q", ann.NodeID, "node-a")
+	}
+	if ann.Hash != "abc123" {
+		t.Errorf("Hash: got %q want %q", ann.Hash, "abc123")
+	}
+	if ann.APIAddr != ":8080" {
+		t.Errorf("APIAddr: got %q want %q", ann.APIAddr, ":8080")
+	}
+	if ann.LocalIP != "192.168.1.99" {
+		t.Errorf("LocalIP: got %q want %q", ann.LocalIP, "192.168.1.99")
+	}
+	if ann.Src != src {
+		t.Errorf("Src: got %v want %v", ann.Src, src)
+	}
+}
+
+func TestParseAnnouncement_RejectsWrongFieldCount(t *testing.T) {
+	cases := []string{
+		"",
+		"only-one",
+		"a|b",
+		"a|b|c",
+		"a|b|c|d|e",
+	}
+	for _, c := range cases {
+		if _, ok := ParseAnnouncement(c, nil); ok {
+			t.Errorf("ParseAnnouncement(%q) should have returned ok=false", c)
+		}
+	}
+}
+
+func TestParseAnnouncement_PreservesEmptyFields(t *testing.T) {
+	// If a future bug ships a packet with empty fields, the parser should
+	// still recognise its shape and let the handler decide what to do with
+	// the empties — silently dropping is worse.
+	ann, ok := ParseAnnouncement("||abc|", nil)
+	if !ok {
+		t.Fatal("expected parse to succeed for 4-field packet with empty fields")
+	}
+	if ann.NodeID != "" || ann.Hash != "" || ann.APIAddr != "abc" || ann.LocalIP != "" {
+		t.Errorf("unexpected fields: %+v", ann)
+	}
+}

--- a/src/discovery/handler.go
+++ b/src/discovery/handler.go
@@ -1,0 +1,61 @@
+package discovery
+
+import (
+	"fmt"
+
+	"axial/models"
+	"axial/remote"
+	"axial/synchronization"
+)
+
+// Handler reacts to a parsed Announcement. The multicast listener calls
+// Handle once per well-formed discovery packet — exactly one adapter in
+// production (SyncOnMismatchHandler) and one in tests, so the interface
+// earns its keep as a real seam between the socket layer and the
+// decision-to-sync logic.
+type Handler interface {
+	Handle(Announcement)
+}
+
+// SyncOnMismatchHandler triggers a sync round when the remote Node's
+// announced FullHash differs from ours. The three function-valued fields
+// are injection points: production wires them to models/synchronization;
+// tests substitute stubs to exercise the decision logic without a database
+// or HTTP client.
+type SyncOnMismatchHandler struct {
+	Hashes    func() models.HashSet
+	Busy      func() bool
+	StartSync func(node remote.API, hash string) error
+}
+
+// NewSyncOnMismatchHandler wires the production dependencies.
+func NewSyncOnMismatchHandler() *SyncOnMismatchHandler {
+	return &SyncOnMismatchHandler{
+		Hashes:    models.GetHashes,
+		Busy:      models.IsSyncing,
+		StartSync: synchronization.StartSync,
+	}
+}
+
+func (h *SyncOnMismatchHandler) Handle(ann Announcement) {
+	if h.Busy() {
+		fmt.Printf("Ignoring ping from %s because we're already syncing\n", ann.Src)
+		return
+	}
+
+	ourHash := h.Hashes().Full
+	if ann.Hash == ourHash {
+		fmt.Printf("Matching hash from %s\n", ann.Src)
+		return
+	}
+
+	fmt.Printf("Mismatching hash from %s: %s != %s\n", ann.Src, ann.Hash, ourHash)
+	remoteNode := remote.API{
+		Address: fmt.Sprintf("%s%s", ann.Src.IP, ann.APIAddr),
+	}
+	if err := h.StartSync(remoteNode, ann.Hash); err != nil {
+		fmt.Printf("Failed to start sync: %v\n", err)
+		return
+	}
+	fmt.Printf("Synchronized with %s\n", remoteNode.Address)
+}

--- a/src/discovery/handler_test.go
+++ b/src/discovery/handler_test.go
@@ -1,0 +1,82 @@
+package discovery
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"axial/models"
+	"axial/remote"
+)
+
+func TestSyncOnMismatchHandler_TriggersOnMismatch(t *testing.T) {
+	var captured remote.API
+	var capturedHash string
+	calls := 0
+
+	h := &SyncOnMismatchHandler{
+		Hashes: func() models.HashSet { return models.HashSet{Full: "ours"} },
+		Busy:   func() bool { return false },
+		StartSync: func(node remote.API, hash string) error {
+			calls++
+			captured = node
+			capturedHash = hash
+			return nil
+		},
+	}
+
+	src := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 45678}
+	h.Handle(Announcement{
+		NodeID:  "remote-node",
+		Hash:    "theirs",
+		APIAddr: ":8080",
+		Src:     src,
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected exactly one StartSync call, got %d", calls)
+	}
+	if captured.Address != "10.0.0.1:8080" {
+		t.Errorf("Address: got %q want %q", captured.Address, "10.0.0.1:8080")
+	}
+	if capturedHash != "theirs" {
+		t.Errorf("hash: got %q want %q", capturedHash, "theirs")
+	}
+}
+
+func TestSyncOnMismatchHandler_SkipsWhenBusy(t *testing.T) {
+	calls := 0
+	h := &SyncOnMismatchHandler{
+		Hashes:    func() models.HashSet { return models.HashSet{Full: "ours"} },
+		Busy:      func() bool { return true },
+		StartSync: func(remote.API, string) error { calls++; return nil },
+	}
+	h.Handle(Announcement{Hash: "theirs", Src: &net.UDPAddr{}})
+	if calls != 0 {
+		t.Errorf("StartSync should not be called when already syncing; got %d calls", calls)
+	}
+}
+
+func TestSyncOnMismatchHandler_SkipsWhenHashMatches(t *testing.T) {
+	calls := 0
+	h := &SyncOnMismatchHandler{
+		Hashes:    func() models.HashSet { return models.HashSet{Full: "same"} },
+		Busy:      func() bool { return false },
+		StartSync: func(remote.API, string) error { calls++; return nil },
+	}
+	h.Handle(Announcement{Hash: "same", Src: &net.UDPAddr{}})
+	if calls != 0 {
+		t.Errorf("StartSync should not be called when hashes match; got %d calls", calls)
+	}
+}
+
+func TestSyncOnMismatchHandler_StartSyncErrorIsNotFatal(t *testing.T) {
+	// A failed sync round must not panic — the handler will be called again
+	// on the next broadcast and should remain usable.
+	h := &SyncOnMismatchHandler{
+		Hashes:    func() models.HashSet { return models.HashSet{Full: "ours"} },
+		Busy:      func() bool { return false },
+		StartSync: func(remote.API, string) error { return errors.New("boom") },
+	}
+	h.Handle(Announcement{Hash: "theirs", Src: &net.UDPAddr{IP: net.ParseIP("1.2.3.4")}})
+}

--- a/src/discovery/multicast.go
+++ b/src/discovery/multicast.go
@@ -11,8 +11,6 @@ import (
 
 	"axial/config"
 	"axial/models"
-	"axial/remote"
-	"axial/synchronization"
 )
 
 // New type to hold our connections
@@ -241,7 +239,12 @@ func setupMulticastConn(cfg config.Config, iface *net.Interface, addr *net.UDPAd
 	return conn, nil
 }
 
-func StartMulticastListener(cfg config.Config, conn *MulticastConnection) {
+// StartMulticastListener reads UDP datagrams and forwards every well-formed
+// Announcement to handler.Handle on a fresh goroutine. The socket layer
+// stays here; the decision-to-sync logic lives behind the Handler seam.
+// Running the handler in its own goroutine means a slow sync round can no
+// longer block the read loop.
+func StartMulticastListener(cfg config.Config, conn *MulticastConnection, handler Handler) {
 	fmt.Printf("Listening for messages on %v\n", conn.Conn.LocalAddr())
 	buffer := make([]byte, 4096)
 
@@ -254,7 +257,7 @@ func StartMulticastListener(cfg config.Config, conn *MulticastConnection) {
 
 		message := string(buffer[:n])
 
-		// Check for both our configured port and the Mac's port (60090)
+		// Diagnostic logging for packets arriving on an unexpected source port.
 		if !strings.Contains(src.String(), fmt.Sprintf(":%d", cfg.MulticastPort)) {
 			if strings.Contains(src.String(), ":60090") {
 				fmt.Printf("Got message on port 60090 from %s: %q\n", src, message)
@@ -263,43 +266,14 @@ func StartMulticastListener(cfg config.Config, conn *MulticastConnection) {
 			}
 		}
 
-		// Only process messages that look like ours (4 pipe-separated fields)
-		if parts := strings.Split(message, "|"); len(parts) == 4 {
-			fmt.Printf("RECV: %s (from %s)\n", message, src)
-			// axial.local|74d63e48f0e18e7c300904b49457a630ec782c244fb212273742ce1499cd21ef|:8080|0.0.0.0 (from 192.168.1.207:45678)
-			if !models.IsSyncing() {
-				hash := parts[1]
-				ourHashes := models.GetHashes()
-				if err != nil {
-					fmt.Printf("Failed to get database hash: %v\n", err)
-					continue
-				}
-				ourHash := ourHashes.Full
-
-				if hash != ourHash {
-					fmt.Printf("Mismatching hash from %s: %s != %s\n", src, hash, ourHash)
-					port := parts[2]
-					remoteNode := remote.API{
-						Address: fmt.Sprintf("%s%s", src.IP, port),
-					}
-					
-					err := synchronization.StartSync(remoteNode, hash)
-					if err != nil {
-						fmt.Printf("Failed to start sync: %v\n", err)
-					} else {
-						fmt.Printf("Synchronized with %s\n", remoteNode.Address)
-					}
-				} else {
-					fmt.Printf("Matching hash from %s\n", src)
-				}
-			} else {
-				fmt.Printf("Ignoring ping from %s because we're already syncing\n", src)
-			}
-
-		} else {
-			// Debug log for non-matching messages
+		ann, ok := ParseAnnouncement(message, src)
+		if !ok {
 			fmt.Printf("Ignored non-axial message from %s (len=%d)\n", src, len(message))
+			continue
 		}
+
+		fmt.Printf("RECV: %s (from %s)\n", message, src)
+		go handler.Handle(ann)
 	}
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -48,9 +48,10 @@ func main() {
 		panic(err)
 	}
 
+	syncHandler := discovery.NewSyncOnMismatchHandler()
 	for _, conn := range connections {
 		defer conn.Conn.Close()
-		go discovery.StartMulticastListener(cfg, &conn)
+		go discovery.StartMulticastListener(cfg, &conn, syncHandler)
 		go discovery.StartBroadcast(cfg, &conn)
 	}
 


### PR DESCRIPTION
## Summary

- Introduces a `Handler` seam between socket I/O and the decision-to-sync logic. The 329-line `multicast.go` no longer fuses parsing, hash comparison, and `synchronization.StartSync` inside the read goroutine.
- New `discovery.Announcement` + pure `ParseAnnouncement` function — parses `"NodeID|FullHash|APIAddr|LocalIP"` packets with no I/O.
- New `discovery.SyncOnMismatchHandler` with function-valued dependencies (`Hashes`, `Busy`, `StartSync`). Production wires them to `models`/`synchronization`; tests substitute stubs.
- `StartMulticastListener` is now a thin shim that dispatches every well-formed packet to `go handler.Handle(ann)` — a stuck sync round can no longer block the listener.
- The `discovery` package drops its imports of `axial/remote` and `axial/synchronization`; the production handler still wires them in but the listener no longer needs them.
- The `discovery` package previously had **zero tests**; this PR adds 7 (3 for `ParseAnnouncement`, 4 for `SyncOnMismatchHandler`).

Closes #24

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./... -race -count=1` passes (7 new `discovery` tests; existing `synchronization` tests unchanged)
- [ ] Manual: bring up a multi-node Tilt environment, confirm sync still triggers on hash mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)