### PR TITLE
Give Hash Range its own module

### DIFF
--- a/src/api/sync.go
+++ b/src/api/sync.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"axial/hashrange"
 	"axial/models"
 	"encoding/json"
 	"fmt"
@@ -16,20 +17,20 @@ const (
 )
 
 type SyncRequest struct {
-	MessageRanges  []models.HashedPeriod     `json:"message_ranges"`
-	BulletinRanges []models.HashedPeriod     `json:"bulletin_ranges,omitempty"`
-	Users          []models.HashedUsersRange `json:"users"`
+	MessageRanges  []hashrange.HashedPeriod     `json:"message_ranges"`
+	BulletinRanges []hashrange.HashedPeriod     `json:"bulletin_ranges,omitempty"`
+	Users          []hashrange.HashedUsersRange `json:"users"`
 }
 
 type SyncResponse struct {
-	Hashes          models.HashSet            `json:"hash"`
-	IsBusy          bool                      `json:"is_busy"`
-	MessageRanges   []models.HashedPeriod     `json:"message_ranges,omitempty"`
-	Messages        []models.MessagesPeriod   `json:"messages,omitempty"`
-	BulletinRanges  []models.HashedPeriod     `json:"bulletin_ranges,omitempty"`
-	Bulletins       []models.BulletinsPeriod  `json:"bulletins,omitempty"`
-	UserRangeHashes []models.HashedUsersRange `json:"user_range_hashes,omitempty"`
-	Users           []models.UsersRange       `json:"users,omitempty"`
+	Hashes          models.HashSet               `json:"hash"`
+	IsBusy          bool                         `json:"is_busy"`
+	MessageRanges   []hashrange.HashedPeriod     `json:"message_ranges,omitempty"`
+	Messages        []models.MessagesPeriod      `json:"messages,omitempty"`
+	BulletinRanges  []hashrange.HashedPeriod     `json:"bulletin_ranges,omitempty"`
+	Bulletins       []models.BulletinsPeriod     `json:"bulletins,omitempty"`
+	UserRangeHashes []hashrange.HashedUsersRange `json:"user_range_hashes,omitempty"`
+	Users           []models.UsersRange          `json:"users,omitempty"`
 }
 
 func handleSync(w http.ResponseWriter, r *http.Request) {
@@ -79,9 +80,9 @@ func handleSyncRequest(w http.ResponseWriter, r *http.Request) {
 func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 
 	// Messages
-	messagePeriods := []models.Period{}
+	messagePeriods := []hashrange.Period{}
 	for _, period := range req.MessageRanges {
-		messagePeriods = append(messagePeriods, models.Period{
+		messagePeriods = append(messagePeriods, hashrange.Period{
 			Start: period.Start,
 			End:   period.End,
 		})
@@ -95,13 +96,13 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 	}
 	fmt.Printf("Generated %d message hash ranges\n", len(ourMessagesHashRanges))
 
-	missmatchingMessagesRanges := []models.HashedPeriod{}
+	missmatchingMessagesRanges := []hashrange.HashedPeriod{}
 	for _, ourRange := range ourMessagesHashRanges {
-		ourStart := models.RealizeStart(ourRange.Start)
-		ourEnd := models.RealizeEnd(ourRange.End)
+		ourStart := hashrange.RealizeStart(ourRange.Start)
+		ourEnd := hashrange.RealizeEnd(ourRange.End)
 		for _, theirRange := range req.MessageRanges {
-			theirStart := models.RealizeStart(theirRange.Start)
-			theirEnd := models.RealizeEnd(theirRange.End)
+			theirStart := hashrange.RealizeStart(theirRange.Start)
+			theirEnd := hashrange.RealizeEnd(theirRange.End)
 			if ourStart.Equal(theirStart) && ourEnd.Equal(theirEnd) {
 				if ourRange.Hash != theirRange.Hash {
 					fmt.Printf("Found mismatching hash for range %v to %v (our hash: %s, their hash: %s)\n",
@@ -123,7 +124,7 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 
 	counts := map[int]int64{}
 	for index, mismatchingRange := range missmatchingMessagesRanges {
-		period := models.Period{
+		period := hashrange.Period{
 			Start: mismatchingRange.Start,
 			End:   mismatchingRange.End,
 		}
@@ -170,14 +171,14 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 			// in the next step instead of further hashed range juggling.
 			splits := int(counts[index]/(maxBatchSize*10)) + 1
 			fmt.Printf("Splitting range into %d parts\n", splits)
-			periods := models.SplitTimeRange(mismatchingRange.Period, splits)
+			periods := hashrange.SplitTimeRange(mismatchingRange.Period, splits)
 			for _, period := range periods {
-				hashedMessagePeriods, err := models.GetMessagesHashRanges(db, []models.Period{period})
+				hashedMessagePeriods, err := models.GetMessagesHashRanges(db, []hashrange.Period{period})
 				if err != nil {
 					return SyncResponse{}, fmt.Errorf("failed to generate hash ranges for split: %v", err)
 				}
 				for _, hashedMessagesPeriod := range hashedMessagePeriods {
-					resp.MessageRanges = append(resp.MessageRanges, models.HashedPeriod{
+					resp.MessageRanges = append(resp.MessageRanges, hashrange.HashedPeriod{
 						Period: hashedMessagesPeriod.Period,
 						Hash:   hashedMessagesPeriod.Hash,
 					})
@@ -187,9 +188,9 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 	}
 
 	// Bulletins (similar logic can be added here)
-	bulletinPeriods := []models.Period{}
+	bulletinPeriods := []hashrange.Period{}
 	for _, period := range req.BulletinRanges {
-		bulletinPeriods = append(bulletinPeriods, models.Period{
+		bulletinPeriods = append(bulletinPeriods, hashrange.Period{
 			Start: period.Start,
 			End:   period.End,
 		})
@@ -202,13 +203,13 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 	}
 	fmt.Printf("Generated %d bulletin hash ranges\n", len(ourBulletinHashRanges))
 
-	mismatchingBulletinRanges := []models.HashedPeriod{}
+	mismatchingBulletinRanges := []hashrange.HashedPeriod{}
 	for _, ourRange := range ourBulletinHashRanges {
-		ourStart := models.RealizeStart(ourRange.Start)
-		ourEnd := models.RealizeEnd(ourRange.End)
+		ourStart := hashrange.RealizeStart(ourRange.Start)
+		ourEnd := hashrange.RealizeEnd(ourRange.End)
 		for _, theirRange := range req.BulletinRanges {
-			theirStart := models.RealizeStart(theirRange.Start)
-			theirEnd := models.RealizeEnd(theirRange.End)
+			theirStart := hashrange.RealizeStart(theirRange.Start)
+			theirEnd := hashrange.RealizeEnd(theirRange.End)
 			if ourStart == theirStart && ourEnd == theirEnd {
 				if ourRange.Hash != theirRange.Hash {
 					fmt.Printf("Found mismatching hash for bulletin range %v to %v (our hash: %s, their hash: %s)\n",
@@ -221,7 +222,7 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 	fmt.Printf("Found %d mismatching bulletin hash ranges\n", len(mismatchingBulletinRanges))
 
 	for _, mismatchingRange := range mismatchingBulletinRanges {
-		period := models.Period{
+		period := hashrange.Period{
 			Start: mismatchingRange.Start,
 			End:   mismatchingRange.End,
 		}
@@ -238,9 +239,9 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 	}
 
 	// Users
-	userRanges := []models.StringRange{}
+	userRanges := []hashrange.StringRange{}
 	for _, ur := range req.Users {
-		userRanges = append(userRanges, models.StringRange{
+		userRanges = append(userRanges, hashrange.StringRange{
 			Start: ur.Start,
 			End:   ur.End,
 		})
@@ -253,7 +254,7 @@ func ComputeSyncResponse(db *gorm.DB, req SyncRequest) (SyncResponse, error) {
 	}
 	fmt.Printf("Generated %d user range hashes\n", len(ourUserRangeHashes))
 
-	mismatchingUserRanges := []models.HashedUsersRange{}
+	mismatchingUserRanges := []hashrange.HashedUsersRange{}
 	for _, ourRange := range ourUserRangeHashes {
 		ourStart := ourRange.Start
 		ourEnd := ourRange.End

--- a/src/hashrange/initial.go
+++ b/src/hashrange/initial.go
@@ -1,0 +1,90 @@
+package hashrange
+
+import (
+	"fmt"
+	"time"
+)
+
+// InitialPeriods returns the coarse-grained time windows a Node uses to
+// bootstrap a sync round. The layout is recent-week + 1-month + 6-month +
+// 2-year + everything-older, descending in granularity so that recent data
+// reconciles fast and stale data is checked at coarse resolution.
+func InitialPeriods() []Period {
+	earliestStartTime := RealizeStart(nil)
+	latestEndTime := RealizeEnd(nil)
+
+	periodSteps := []struct {
+		Years  int
+		Months int
+		Days   int
+	}{
+		{0, -1, 0},
+		{0, -6, 0},
+		{-2, 0, 0},
+	}
+
+	var previousStart *time.Time
+	weekStart := weekStartOf(time.Now())
+	if weekStart.Before(earliestStartTime) {
+		previousStart = &earliestStartTime
+	} else {
+		previousStart = &weekStart
+	}
+
+	periods := []Period{
+		{Start: previousStart, End: &latestEndTime},
+	}
+
+	for _, step := range periodSteps {
+		start := previousStart.AddDate(step.Years, step.Months, step.Days)
+		if start.Before(earliestStartTime) {
+			periods = append(periods, Period{
+				Start: &earliestStartTime,
+				End:   previousStart,
+			})
+			break
+		}
+		periods = append(periods, Period{
+			Start: &start,
+			End:   previousStart,
+		})
+		previousStart = &start
+	}
+
+	periods = append(periods, Period{
+		Start: &earliestStartTime,
+		End:   previousStart,
+	})
+
+	return periods
+}
+
+// InitialFingerprintRanges returns the lexicographic partitions a Node uses
+// to bootstrap user sync: one window per digit (0-9) and one per
+// lower-case letter (a-z). Fingerprints are hex strings, so 0-9 and a-f
+// carry actual users; g-z exist to keep the partition uniform without
+// special-casing.
+func InitialFingerprintRanges() []StringRange {
+	var ranges []StringRange
+	for i := 0; i < 10; i++ {
+		ranges = append(ranges, StringRange{
+			Start: fmt.Sprintf("%c", '0'+i),
+			End:   fmt.Sprintf("%c", '0'+i+1),
+		})
+	}
+	for i := 0; i < 25; i++ {
+		ranges = append(ranges, StringRange{
+			Start: fmt.Sprintf("%c", 'a'+i),
+			End:   fmt.Sprintf("%c", 'a'+i+1),
+		})
+	}
+	return ranges
+}
+
+func weekStartOf(now time.Time) time.Time {
+	weekday := now.Weekday()
+	if weekday == time.Sunday {
+		weekday = 7
+	}
+	return now.AddDate(0, 0, -int(weekday-time.Monday)).Truncate(24 * time.Hour)
+}

--- a/src/hashrange/initial_test.go
+++ b/src/hashrange/initial_test.go
@@ -1,0 +1,42 @@
+package hashrange
+
+import (
+	"testing"
+)
+
+func TestInitialPeriods_ProducesAtLeastOneWindow(t *testing.T) {
+	periods := InitialPeriods()
+	if len(periods) == 0 {
+		t.Fatal("expected at least one initial period")
+	}
+}
+
+func TestInitialPeriods_AllWindowsHaveResolvedBounds(t *testing.T) {
+	for i, p := range InitialPeriods() {
+		if p.Start == nil {
+			t.Errorf("period %d has nil Start", i)
+		}
+		if p.End == nil {
+			t.Errorf("period %d has nil End", i)
+		}
+		if p.Start != nil && p.End != nil && !p.End.After(*p.Start) {
+			t.Errorf("period %d has non-positive duration: %v..%v", i, *p.Start, *p.End)
+		}
+	}
+}
+
+func TestInitialFingerprintRanges_CoversDigitsAndLowercase(t *testing.T) {
+	ranges := InitialFingerprintRanges()
+	if len(ranges) != 35 { // 10 digits + 25 letters
+		t.Errorf("expected 35 ranges (10 digits + 25 letters), got %d", len(ranges))
+	}
+	if ranges[0].Start != "0" {
+		t.Errorf("first range should start at '0', got %q", ranges[0].Start)
+	}
+	if ranges[9].Start != "9" {
+		t.Errorf("tenth range should start at '9', got %q", ranges[9].Start)
+	}
+	if ranges[10].Start != "a" {
+		t.Errorf("eleventh range should start at 'a', got %q", ranges[10].Start)
+	}
+}

--- a/src/hashrange/match.go
+++ b/src/hashrange/match.go
@@ -1,0 +1,24 @@
+package hashrange
+
+// MismatchedPeriods returns the entries from `theirs` whose Period bounds
+// match an entry in `ours` but whose Hash differs. Used by the sync round
+// orchestrator to decide which time windows still need drilling after a
+// hash exchange.
+//
+// The comparison is order-independent and quadratic in the input size;
+// the inputs are tiny (a handful of periods per round) so this is fine.
+func MismatchedPeriods(ours, theirs []HashedPeriod) []HashedPeriod {
+	out := []HashedPeriod{}
+	for _, our := range ours {
+		ourStart := RealizeStart(our.Start)
+		ourEnd := RealizeEnd(our.End)
+		for _, their := range theirs {
+			theirStart := RealizeStart(their.Start)
+			theirEnd := RealizeEnd(their.End)
+			if ourStart.Equal(theirStart) && ourEnd.Equal(theirEnd) && our.Hash != their.Hash {
+				out = append(out, their)
+			}
+		}
+	}
+	return out
+}

--- a/src/hashrange/match_test.go
+++ b/src/hashrange/match_test.go
@@ -1,0 +1,64 @@
+package hashrange
+
+import (
+	"testing"
+	"time"
+)
+
+func hp(start, end time.Time, hash string) HashedPeriod {
+	return HashedPeriod{
+		Period: Period{Start: &start, End: &end},
+		Hash:   hash,
+	}
+}
+
+func TestMismatchedPeriods_ReturnsOnlyDifferingBoundsMatch(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	ours := []HashedPeriod{
+		hp(t1, t2, "AAA"),
+		hp(t2, t3, "BBB"),
+	}
+	theirs := []HashedPeriod{
+		hp(t1, t2, "AAA"), // same window, same hash — not mismatched
+		hp(t2, t3, "ZZZ"), // same window, different hash — mismatched
+	}
+
+	got := MismatchedPeriods(ours, theirs)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 mismatch, got %d: %+v", len(got), got)
+	}
+	if got[0].Hash != "ZZZ" {
+		t.Errorf("returned hash should be theirs (ZZZ), got %q", got[0].Hash)
+	}
+}
+
+func TestMismatchedPeriods_IgnoresNonOverlappingBounds(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)
+	t4 := time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)
+
+	ours := []HashedPeriod{hp(t1, t2, "AAA")}
+	theirs := []HashedPeriod{hp(t3, t4, "BBB")} // different window entirely
+
+	got := MismatchedPeriods(ours, theirs)
+	if len(got) != 0 {
+		t.Errorf("expected no mismatch (windows don't overlap), got %+v", got)
+	}
+}
+
+func TestMismatchedPeriods_FullyMatchingSetReturnsEmpty(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	ours := []HashedPeriod{hp(t1, t2, "AAA")}
+	theirs := []HashedPeriod{hp(t1, t2, "AAA")}
+
+	got := MismatchedPeriods(ours, theirs)
+	if len(got) != 0 {
+		t.Errorf("matching set should produce no mismatches, got %+v", got)
+	}
+}

--- a/src/hashrange/range.go
+++ b/src/hashrange/range.go
@@ -1,0 +1,68 @@
+// Package hashrange owns the Hash Range domain concept: the bounded windows
+// (time or fingerprint) over which a Node computes content hashes during a
+// sync round, plus the math used to drill those windows down to the smallest
+// mismatching slice.
+//
+// ARCHITECTURE.md treats Hash Range as a first-class glossary term; this
+// package is its home. DB-touching code that *produces* hashes for a range
+// lives in the models package — hashrange itself depends on nothing but the
+// standard library so its math is unit-testable in isolation.
+package hashrange
+
+import "time"
+
+// Period is a half-open time window with optional bounds. A nil Start means
+// "from the dawn of the dataset" (see RealizeStart); a nil End means "up to
+// now" (see RealizeEnd).
+type Period struct {
+	Start *time.Time `json:"start,omitempty"`
+	End   *time.Time `json:"end,omitempty"`
+}
+
+// HashedPeriod is a Period together with the content hash a Node computed
+// for that window. Exchanged during a sync round so peers can decide which
+// windows differ.
+type HashedPeriod struct {
+	Period
+	Hash string `json:"hash"`
+}
+
+// StringRange is a half-open lexicographic window — used for partitioning
+// the Fingerprint key-space during user sync.
+type StringRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// HashedUsersRange is a StringRange together with the hash of the user
+// fingerprints inside it.
+type HashedUsersRange struct {
+	StringRange
+	Hash string `json:"hash"`
+}
+
+// HashedFilesRange mirrors HashedUsersRange for file sync (placeholder for
+// the FUTURE file-attachment work in ARCHITECTURE.md).
+type HashedFilesRange struct {
+	StringRange
+	Hash string `json:"hash"`
+}
+
+// RealizeStart resolves a possibly-nil Period.Start to a concrete time.
+// nil means "from the release year (2025-01-01 UTC)" — the earliest data
+// that can exist on the network.
+func RealizeStart(start *time.Time) time.Time {
+	if start == nil {
+		return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+	return *start
+}
+
+// RealizeEnd resolves a possibly-nil Period.End to a concrete time. nil
+// means "up to now."
+func RealizeEnd(end *time.Time) time.Time {
+	if end == nil {
+		return time.Now()
+	}
+	return *end
+}

--- a/src/hashrange/range_test.go
+++ b/src/hashrange/range_test.go
@@ -1,0 +1,39 @@
+package hashrange
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRealizeStart_DefaultsToReleaseYear(t *testing.T) {
+	got := RealizeStart(nil)
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("RealizeStart(nil) = %v, want %v", got, want)
+	}
+}
+
+func TestRealizeStart_PassesThroughNonNil(t *testing.T) {
+	want := time.Date(2030, 6, 15, 12, 0, 0, 0, time.UTC)
+	got := RealizeStart(&want)
+	if !got.Equal(want) {
+		t.Errorf("RealizeStart(&t) = %v, want %v", got, want)
+	}
+}
+
+func TestRealizeEnd_DefaultsToNow(t *testing.T) {
+	before := time.Now()
+	got := RealizeEnd(nil)
+	after := time.Now()
+	if got.Before(before) || got.After(after) {
+		t.Errorf("RealizeEnd(nil) = %v, want within [%v, %v]", got, before, after)
+	}
+}
+
+func TestRealizeEnd_PassesThroughNonNil(t *testing.T) {
+	want := time.Date(2030, 6, 15, 12, 0, 0, 0, time.UTC)
+	got := RealizeEnd(&want)
+	if !got.Equal(want) {
+		t.Errorf("RealizeEnd(&t) = %v, want %v", got, want)
+	}
+}

--- a/src/hashrange/split.go
+++ b/src/hashrange/split.go
@@ -1,0 +1,34 @@
+package hashrange
+
+import "time"
+
+// SplitTimeRange divides a Period into n equal sub-Periods. Used during the
+// drill phase of a sync round: when a window's hash mismatches and the
+// data inside it is too large to ship whole, the window is split and each
+// piece gets re-hashed in the next round.
+//
+// The final piece is anchored to the original End to absorb any rounding
+// drift, so the union of returned Periods exactly covers the input.
+func SplitTimeRange(period Period, n int) []Period {
+	start := RealizeStart(period.Start)
+	end := RealizeEnd(period.End)
+
+	duration := end.Sub(start)
+	partDuration := duration / time.Duration(n)
+
+	ranges := make([]Period, n)
+	for i := 0; i < n; i++ {
+		partStart := start.Add(partDuration * time.Duration(i))
+		partEnd := partStart.Add(partDuration)
+		if i == n-1 {
+			partEnd = end
+		}
+
+		ranges[i] = Period{
+			Start: &partStart,
+			End:   &partEnd,
+		}
+	}
+
+	return ranges
+}

--- a/src/hashrange/split_test.go
+++ b/src/hashrange/split_test.go
@@ -1,0 +1,65 @@
+package hashrange
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSplitTimeRange_ProducesNSubPeriods(t *testing.T) {
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 11, 0, 0, 0, 0, time.UTC) // 10 days
+	period := Period{Start: &start, End: &end}
+
+	parts := SplitTimeRange(period, 10)
+	if len(parts) != 10 {
+		t.Fatalf("expected 10 parts, got %d", len(parts))
+	}
+}
+
+func TestSplitTimeRange_CoversInputExactly(t *testing.T) {
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 11, 0, 0, 0, 0, time.UTC)
+	period := Period{Start: &start, End: &end}
+
+	parts := SplitTimeRange(period, 7) // n that doesn't divide evenly
+	if !parts[0].Start.Equal(start) {
+		t.Errorf("first part starts at %v, want %v", *parts[0].Start, start)
+	}
+	if !parts[len(parts)-1].End.Equal(end) {
+		t.Errorf("last part ends at %v, want %v (rounding-drift absorber)", *parts[len(parts)-1].End, end)
+	}
+	for i := 1; i < len(parts); i++ {
+		if !parts[i].Start.Equal(*parts[i-1].End) {
+			t.Errorf("part %d Start %v != part %d End %v (gap or overlap)",
+				i, *parts[i].Start, i-1, *parts[i-1].End)
+		}
+	}
+}
+
+func TestSplitTimeRange_NEqualsOneReturnsInput(t *testing.T) {
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 11, 0, 0, 0, 0, time.UTC)
+	period := Period{Start: &start, End: &end}
+
+	parts := SplitTimeRange(period, 1)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	if !parts[0].Start.Equal(start) || !parts[0].End.Equal(end) {
+		t.Errorf("single-part split should reproduce input; got %v..%v", *parts[0].Start, *parts[0].End)
+	}
+}
+
+func TestSplitTimeRange_RealizesNilBounds(t *testing.T) {
+	// nil bounds should be resolved (release year for Start, now for End) and
+	// produce well-formed sub-Periods rather than nil-pointer panics.
+	parts := SplitTimeRange(Period{}, 3)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d", len(parts))
+	}
+	for i, p := range parts {
+		if p.Start == nil || p.End == nil {
+			t.Errorf("part %d has nil bound: %+v", i, p)
+		}
+	}
+}

--- a/src/models/sync.go
+++ b/src/models/sync.go
@@ -3,7 +3,8 @@ package models
 import (
 	"fmt"
 	"sync"
-	"time"
+
+	"axial/hashrange"
 
 	"gorm.io/gorm"
 )
@@ -19,61 +20,23 @@ var (
 	syncState = &SyncState{}
 )
 
-type Period struct {
-	Start *time.Time `json:"start,omitempty"`
-	End   *time.Time `json:"end,omitempty"`
-}
-
-func RealizeStart(start *time.Time) time.Time {
-	if start == nil {
-		// Start at 2025-01-01, the release year
-		return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	}
-	return *start
-}
-
-func RealizeEnd(end *time.Time) time.Time {
-	if end == nil {
-		// End at the current time
-		return time.Now()
-	}
-	return *end
-}
-
-// HashedPeriod represents a time period and its hash
-type HashedPeriod struct {
-	Period
-	Hash string `json:"hash"`
-}
-
+// MessagesPeriod carries the Messages that live within a hash range. The
+// Period bounds are inlined into JSON via the embedded hashrange.Period.
 type MessagesPeriod struct {
-	Period
+	hashrange.Period
 	Messages []Message `json:"messages"`
 }
 
+// BulletinsPeriod carries the Bulletins that live within a hash range.
 type BulletinsPeriod struct {
-	Period
+	hashrange.Period
 	Bulletins []Bulletin `json:"bulletins"`
 }
 
-type StringRange struct {
-	Start string `json:"start"`
-	End   string `json:"end"`
-}
-
+// UsersRange carries the Users that live within a fingerprint hash range.
 type UsersRange struct {
-	StringRange
+	hashrange.StringRange
 	Users []User `json:"users"`
-}
-
-type HashedUsersRange struct {
-	StringRange
-	Hash string `json:"hash"`
-}
-
-type HashedFilesRange struct {
-	StringRange
-	Hash string `json:"hash"`
 }
 
 // StartSync attempts to start a sync operation
@@ -117,15 +80,17 @@ func GetHashes() HashSet {
 	return syncState.hashes
 }
 
-// GetMessagesHashRanges creates the standard set of time ranges to check
-func GetMessagesHashRanges(db *gorm.DB, periods []Period) ([]HashedPeriod, error) {
-	hashedPeriods := []HashedPeriod{}
+// GetMessagesHashRanges computes the message-content hash for each of the
+// supplied hash ranges. Pure-math splitting / comparison of ranges lives in
+// the hashrange package; this function is the DB-touching adapter.
+func GetMessagesHashRanges(db *gorm.DB, periods []hashrange.Period) ([]hashrange.HashedPeriod, error) {
+	hashedPeriods := []hashrange.HashedPeriod{}
 	for _, period := range periods {
 		hash, err := GetMessagesHash(db, period.Start, period.End)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get messages hash: %v", err)
 		}
-		hashedPeriods = append(hashedPeriods, HashedPeriod{
+		hashedPeriods = append(hashedPeriods, hashrange.HashedPeriod{
 			Period: period,
 			Hash:   hash,
 		})
@@ -133,15 +98,16 @@ func GetMessagesHashRanges(db *gorm.DB, periods []Period) ([]HashedPeriod, error
 	return hashedPeriods, nil
 }
 
-// GetBulletinsHashRanges creates hashed ranges for bulletins
-func GetBulletinsHashRanges(db *gorm.DB, periods []Period) ([]HashedPeriod, error) {
-	hashedPeriods := []HashedPeriod{}
+// GetBulletinsHashRanges computes the bulletin-content hash for each of the
+// supplied hash ranges.
+func GetBulletinsHashRanges(db *gorm.DB, periods []hashrange.Period) ([]hashrange.HashedPeriod, error) {
+	hashedPeriods := []hashrange.HashedPeriod{}
 	for _, period := range periods {
 		hash, err := GetBulletinsHash(db, period.Start, period.End)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get bulletins hash: %v", err)
 		}
-		hashedPeriods = append(hashedPeriods, HashedPeriod{
+		hashedPeriods = append(hashedPeriods, hashrange.HashedPeriod{
 			Period: period,
 			Hash:   hash,
 		})
@@ -149,14 +115,16 @@ func GetBulletinsHashRanges(db *gorm.DB, periods []Period) ([]HashedPeriod, erro
 	return hashedPeriods, nil
 }
 
-func GetUsersHashRanges(db *gorm.DB, stringRanges []StringRange) ([]HashedUsersRange, error) {
-	hashedRanges := []HashedUsersRange{}
+// GetUsersHashRanges computes the user-content hash for each of the supplied
+// fingerprint hash ranges.
+func GetUsersHashRanges(db *gorm.DB, stringRanges []hashrange.StringRange) ([]hashrange.HashedUsersRange, error) {
+	hashedRanges := []hashrange.HashedUsersRange{}
 	for _, stringRange := range stringRanges {
 		hash, err := GetUsersHashByFingerprintRange(db, stringRange.Start, stringRange.End)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get users hash: %v", err)
 		}
-		hashedRanges = append(hashedRanges, HashedUsersRange{
+		hashedRanges = append(hashedRanges, hashrange.HashedUsersRange{
 			StringRange: stringRange,
 			Hash:        hash,
 		})
@@ -165,50 +133,25 @@ func GetUsersHashRanges(db *gorm.DB, stringRanges []StringRange) ([]HashedUsersR
 	return hashedRanges, nil
 }
 
-// SplitTimeRange splits a time range into n equal parts
-func SplitTimeRange(period Period, n int) []Period {
-	start := RealizeStart(period.Start)
-	end := RealizeEnd(period.End)
-
-	duration := end.Sub(start)
-	partDuration := duration / time.Duration(n)
-
-	ranges := make([]Period, n)
-	for i := 0; i < n; i++ {
-		partStart := start.Add(partDuration * time.Duration(i))
-		partEnd := partStart.Add(partDuration)
-		if i == n-1 {
-			partEnd = end // Ensure we don't miss any time due to rounding
-		}
-
-		ranges[i] = Period{
-			Start: &partStart,
-			End:   &partEnd,
-		}
-	}
-
-	return ranges
-}
-
-func GetMessagesByPeriod(db *gorm.DB, period Period) ([]Message, error) {
+func GetMessagesByPeriod(db *gorm.DB, period hashrange.Period) ([]Message, error) {
 	var messages []Message
 	err := db.Where("created_at >= ? AND created_at < ?", period.Start, period.End).Find(&messages).Error
 	return messages, err
 }
 
-func CountMessagesByPeriod(db *gorm.DB, period Period) int64 {
+func CountMessagesByPeriod(db *gorm.DB, period hashrange.Period) int64 {
 	var count int64
 	db.Model(&Message{}).Where("created_at >= ? AND created_at < ?", period.Start, period.End).Count(&count)
 	return count
 }
 
-func GetBulletinsByPeriod(db *gorm.DB, period Period) ([]Bulletin, error) {
+func GetBulletinsByPeriod(db *gorm.DB, period hashrange.Period) ([]Bulletin, error) {
 	var bulletins []Bulletin
 	err := db.Where("created_at >= ? AND created_at < ?", period.Start, period.End).Find(&bulletins).Error
 	return bulletins, err
 }
 
-func CountBulletinsByPeriod(db *gorm.DB, period Period) int64 {
+func CountBulletinsByPeriod(db *gorm.DB, period hashrange.Period) int64 {
 	var count int64
 	db.Model(&Bulletin{}).Where("created_at >= ? AND created_at < ?", period.Start, period.End).Count(&count)
 	return count

--- a/src/synchronization/sync_integration_test.go
+++ b/src/synchronization/sync_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"axial/api"
+	"axial/hashrange"
 	"axial/models"
 	"axial/remote"
 	"strings"
@@ -165,7 +166,7 @@ func TestFullSyncConverges(t *testing.T) {
     insertMessage(t, dbB, m3)
 
     // Prepare ranges
-    periods, _ := startingSyncRanges()
+    periods := hashrange.InitialPeriods()
     hashedA, err := models.GenerateHashRanges(dbA, periods)
     if err != nil { t.Fatalf("hash ranges A: %v", err) }
     hashedB, err := models.GenerateHashRanges(dbB, periods)

--- a/src/synchronization/sync_process.go
+++ b/src/synchronization/sync_process.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"axial/api"
+	"axial/hashrange"
 	"axial/models"
 	"axial/remote"
 )
@@ -68,7 +68,8 @@ func StartSync(node remote.API, hash string) error {
 	}
 	defer models.EndSync()
 
-	periods, stringRanges := startingSyncRanges()
+	periods := hashrange.InitialPeriods()
+	stringRanges := hashrange.InitialFingerprintRanges()
 	hashedMessagesPeriods, err := models.GetMessagesHashRanges(models.DB, periods)
 	if err != nil {
 		return err
@@ -133,13 +134,13 @@ func SortBulletins(bulletins []models.Bulletin) {
 //
 // For unit tests, prefer calling SyncWithRequester with a custom requester that
 // uses in-memory handlers to return api.SyncResponse.
-func Sync(node remote.API, hashedMessagePeriods []models.HashedPeriod, hashedBulletinPeriods []models.HashedPeriod, hashedUsers []models.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
+func Sync(node remote.API, hashedMessagePeriods []hashrange.HashedPeriod, hashedBulletinPeriods []hashrange.HashedPeriod, hashedUsers []hashrange.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
 	return SyncWithRequester(httpSyncRequester{}, node, hashedMessagePeriods, hashedBulletinPeriods, hashedUsers)
 }
 
 // SyncWithRequester is identical to Sync but allows the caller to provide a
 // pluggable requester for testability.
-func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesPeriods []models.HashedPeriod, hashedBulletinPeriods []models.HashedPeriod, hashedUsers []models.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
+func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesPeriods []hashrange.HashedPeriod, hashedBulletinPeriods []hashrange.HashedPeriod, hashedUsers []hashrange.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
 	if len(hashedMessagesPeriods) == 0 {
 		fmt.Printf("No periods to sync with %s\n", node.Address)
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, nil
@@ -194,7 +195,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		}
 	}
 
-	periodsForRemoteMessagesHashes := []models.Period{}
+	periodsForRemoteMessagesHashes := []hashrange.Period{}
 	for _, hashedPeriod := range syncResponse.MessageRanges {
 		periodsForRemoteMessagesHashes = append(periodsForRemoteMessagesHashes, hashedPeriod.Period)
 	}
@@ -204,7 +205,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to generate hash ranges: %v", err)
 	}
 
-	hashedMessagesPeriodsToCheck := mismatchedMessagesPeriods(ourMessagesHashes, syncResponse.MessageRanges)
+	hashedMessagesPeriodsToCheck := hashrange.MismatchedPeriods(ourMessagesHashes, syncResponse.MessageRanges)
 
 	// Bulletins
 	bulletinsMissingInRemote := []models.Bulletin{}
@@ -235,7 +236,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		}
 	}
 
-	periodsForRemoteBulletinHashes := []models.Period{}
+	periodsForRemoteBulletinHashes := []hashrange.Period{}
 	for _, hashedPeriod := range syncResponse.BulletinRanges {
 		periodsForRemoteBulletinHashes = append(periodsForRemoteBulletinHashes, hashedPeriod.Period)
 	}
@@ -245,7 +246,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to generate bulletin hash ranges: %v", err)
 	}
 
-	hashedBulletinPeriodsToCheck := mismatchedMessagesPeriods(ourBulletinHashes, syncResponse.BulletinRanges)
+	hashedBulletinPeriodsToCheck := hashrange.MismatchedPeriods(ourBulletinHashes, syncResponse.BulletinRanges)
 
 	// Users
 	usersMissingInRemote := []models.User{}
@@ -291,7 +292,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		}
 	}
 
-	userRangesToCheck := []models.HashedUsersRange{}
+	userRangesToCheck := []hashrange.HashedUsersRange{}
 
 	for _, hashedUserRange := range syncResponse.UserRangeHashes {
 		ourUserHash, err := models.GetUsersHashByFingerprintRange(models.DB, hashedUserRange.Start, hashedUserRange.End)
@@ -341,97 +342,3 @@ func userGroupPrefix(s string) string {
 	return s[:first+1+second]
 }
 
-// mismatchedMessagesPeriods returns the set of hashed periods from the remote that
-// correspond to the same concrete time ranges as ours but have different
-// content hashes.
-func mismatchedMessagesPeriods(our []models.HashedPeriod, theirs []models.HashedPeriod) []models.HashedPeriod {
-	out := []models.HashedPeriod{}
-	for _, ourHash := range our {
-		start := models.RealizeStart(ourHash.Start)
-		end := models.RealizeEnd(ourHash.End)
-		for _, theirHash := range theirs {
-			theirStart := models.RealizeStart(theirHash.Start)
-			theirEnd := models.RealizeEnd(theirHash.End)
-			if theirStart == start && theirEnd == end && theirHash.Hash != ourHash.Hash {
-				out = append(out, theirHash)
-			}
-		}
-	}
-	return out
-}
-
-func startingSyncRanges() ([]models.Period, []models.StringRange) {
-
-	earliestStartTime := models.RealizeStart(nil)
-	latestEndTime := models.RealizeEnd(nil)
-
-	periodSteps := []struct {
-		Years  int `json:"years"`
-		Months int `json:"months"`
-		Days   int `json:"days"`
-	}{
-		{0, -1, 0},
-		{0, -6, 0},
-		{-2, 0, 0},
-	}
-	var previousStart *time.Time
-	weekStart := getWeekStart()
-	if weekStart.Before(earliestStartTime) {
-		previousStart = &earliestStartTime
-	} else {
-		previousStart = &weekStart
-	}
-
-	periods := []models.Period{
-		{
-			Start: previousStart,
-			End:   &latestEndTime,
-		},
-	}
-
-	for _, step := range periodSteps {
-		start := previousStart.AddDate(step.Years, step.Months, step.Days)
-		if start.Before(earliestStartTime) {
-			periods = append(periods, models.Period{
-				Start: &earliestStartTime,
-				End:   previousStart,
-			})
-			break
-		}
-		periods = append(periods, models.Period{
-			Start: &start,
-			End:   previousStart,
-		})
-		previousStart = &start
-	}
-
-	periods = append(periods, models.Period{
-		Start: &earliestStartTime,
-		End:   previousStart,
-	})
-
-	// Generate user fingerprint ranges, an array of 0-9 and a-z
-	var userRanges []models.StringRange
-	for i := 0; i < 10; i++ {
-		userRanges = append(userRanges, models.StringRange{
-			Start: fmt.Sprintf("%c", '0'+i),
-			End:   fmt.Sprintf("%c", '0'+i+1),
-		})
-	}
-	for i := 0; i < 25; i++ {
-		userRanges = append(userRanges, models.StringRange{
-			Start: fmt.Sprintf("%c", 'a'+i),
-			End:   fmt.Sprintf("%c", 'a'+i+1),
-		})
-	}
-	return periods, userRanges
-}
-
-func getWeekStart() time.Time {
-	now := time.Now()
-	weekday := now.Weekday()
-	if weekday == time.Sunday {
-		weekday = 7
-	}
-	return now.AddDate(0, 0, -int(weekday-time.Monday)).Truncate(24 * time.Hour)
-}

--- a/src/synchronization/sync_process_test.go
+++ b/src/synchronization/sync_process_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"axial/api"
+	"axial/hashrange"
 	"axial/models"
 	"axial/remote"
 
@@ -103,14 +104,14 @@ func TestMismatchedPeriods(t *testing.T) {
 	now := time.Now().UTC()
 	earlier := now.Add(-24 * time.Hour)
 
-	our := []models.HashedPeriod{
-		{Period: models.Period{Start: &earlier, End: &now}, Hash: "aaa"},
+	our := []hashrange.HashedPeriod{
+		{Period: hashrange.Period{Start: &earlier, End: &now}, Hash: "aaa"},
 	}
-	theirs := []models.HashedPeriod{
-		{Period: models.Period{Start: &earlier, End: &now}, Hash: "bbb"},
+	theirs := []hashrange.HashedPeriod{
+		{Period: hashrange.Period{Start: &earlier, End: &now}, Hash: "bbb"},
 	}
 
-	out := mismatchedMessagesPeriods(our, theirs)
+	out := hashrange.MismatchedPeriods(our, theirs)
 	if len(out) != 1 {
 		t.Fatalf("expected 1 mismatched period, got %d", len(out))
 	}
@@ -142,7 +143,7 @@ func TestSyncExchangeSkeleton(t *testing.T) {
 	insertUserRawUnit(t, dbB, "FP_A2_"+randStringUnit(t)) // share FP_A2 on B
 	insertUserRawUnit(t, dbB, "FP_B3_"+randStringUnit(t))
 
-	periods, _ := startingSyncRanges()
+	periods := hashrange.InitialPeriods()
 	hashedMessagesA, err := models.GetMessagesHashRanges(dbA, periods)
 	if err != nil {
 		t.Fatalf("hash messages ranges A: %v", err)
@@ -153,7 +154,7 @@ func TestSyncExchangeSkeleton(t *testing.T) {
 		t.Fatalf("hash bulletins ranges A: %v", err)
 	}
 
-	hashedUsersA, err := models.GetUsersHashRanges(dbA, []models.StringRange{{Start: "", End: "zzzz"}})
+	hashedUsersA, err := models.GetUsersHashRanges(dbA, []hashrange.StringRange{{Start: "", End: "zzzz"}})
 	if err != nil {
 		t.Fatalf("hash users ranges A: %v", err)
 	}
@@ -168,7 +169,7 @@ func TestSyncExchangeSkeleton(t *testing.T) {
 		t.Fatalf("hash bulletins ranges B: %v", err)
 	}
 
-	hashedUsersB, err := models.GetUsersHashRanges(dbB, []models.StringRange{{Start: "", End: "zzzz"}})
+	hashedUsersB, err := models.GetUsersHashRanges(dbB, []hashrange.StringRange{{Start: "", End: "zzzz"}})
 	if err != nil {
 		t.Fatalf("hash users ranges B: %v", err)
 	}


### PR DESCRIPTION
## Summary

Hash Range is one of `ARCHITECTURE.md`'s four glossary terms, but the concept had no home — its parts were scattered across `models/sync.go`, `models/hashing_database.go`, `api/sync.go`, and `synchronization/sync_process.go`. This PR consolidates the pure-domain side into a new `hashrange` package.

**New `src/hashrange/` package — std-lib-only, fully unit-testable:**
- `range.go` — `Period`, `HashedPeriod`, `StringRange`, `HashedUsersRange`, `HashedFilesRange` + `RealizeStart`/`RealizeEnd`
- `split.go` — `SplitTimeRange` (rounding-drift absorber preserved)
- `match.go` — `MismatchedPeriods` (renamed from `mismatchedMessagesPeriods` — never was message-specific; the same helper was already used for bulletins)
- `initial.go` — `InitialPeriods` + `InitialFingerprintRanges` (extracted from `startingSyncRanges`, which is now gone)
- **14 new tests** — the package previously had zero coverage despite carrying the heart of the sync algorithm.

**What stays in `models/`:**
- DB-touching adapters (`GetMessagesHashRanges`, `GetBulletinsHashRanges`, `GetUsersHashRanges`) — they now return `hashrange.*` types but the SQL stays where the `*gorm.DB` is.
- `MessagesPeriod` / `BulletinsPeriod` / `UsersRange` — they carry `Message`/`Bulletin`/`User` data and now embed `hashrange.Period` or `hashrange.StringRange`. JSON shape over the wire is preserved (the embed inlines the same fields).

**Call-site impact:**
- `api/sync.go` and `synchronization/sync_process.go` are now call-site updates — every `models.{Period,HashedPeriod,StringRange,HashedUsersRange,SplitTimeRange,RealizeStart,RealizeEnd}` reference points at `hashrange`. The drill-or-return-data decision and the recursive sync round itself are unchanged in spirit; they just speak the new vocabulary.

Net: +510 / −231 (most of that is the new package + its tests).

Closes #25

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./... -race -count=1` passes — 14 new `hashrange` tests + the existing `synchronization` tests (which exercise `MismatchedPeriods` via the integration-style `TestMismatchedPeriods` and the end-to-end exchange test)
- [ ] Manual: bring up a multi-node Tilt environment, confirm a full sync round still drills hash ranges and converges
- [ ] Wire-format check: confirm JSON tags on embedded types match the originals (preserved verbatim in this PR)

## Out of scope (intentionally)

- The drill-or-return-data logic in `api/sync.go` keeps its inline comparison loops. Generalising those to call `hashrange.MismatchedPeriods` would tighten the seam further, but it's a follow-up.
- The pre-existing bug in `models/UpdateHashes` (assigns from the package-level `hashes` var instead of the `hash` parameter) is preserved verbatim — out of scope.
- The `//go:build integration` test file already had stale references (`models.GenerateHashRanges` doesn't exist); only the one call my deletion broke was patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)