### PR TITLE
Inject DB through module boundaries instead of using global models.DB

### DIFF
--- a/src/api/bulletin.go
+++ b/src/api/bulletin.go
@@ -2,20 +2,20 @@ package api
 
 import (
 	"encoding/json"
-	"net/http"
 	"log"
+	"net/http"
 
 	"axial/models"
 )
 
-func handleGetBulletin(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleGetBulletin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	var posts []models.Bulletin
-	if err := models.DB.Order("created_at DESC").Find(&posts).Error; err != nil {
+	if err := s.DB.Order("created_at DESC").Find(&posts).Error; err != nil {
 		http.Error(w, "Failed to fetch bulletin posts", http.StatusInternalServerError)
 		return
 	}
@@ -24,7 +24,7 @@ func handleGetBulletin(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(posts)
 }
 
-func handleCreateBulletin(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleCreateBulletin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -40,13 +40,13 @@ func handleCreateBulletin(w http.ResponseWriter, r *http.Request) {
 		CreateBulletin: req,
 	}
 
-	if err := models.DB.Create(&post).Error; err != nil {
+	if err := s.DB.Create(&post).Error; err != nil {
 		log.Printf("Create bulletin failed: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	models.RefreshHashes(models.DB)
+	models.RefreshHashes(s.DB)
 
 	w.WriteHeader(http.StatusCreated)
 }

--- a/src/api/messages.go
+++ b/src/api/messages.go
@@ -2,21 +2,20 @@ package api
 
 import (
 	"encoding/json"
-	"net/http"
 	"log"
+	"net/http"
 
 	"axial/models"
 )
 
-
-func handleGetMessages(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	var messages []models.Message
-	if err := models.DB.Find(&messages).Error; err != nil {
+	if err := s.DB.Find(&messages).Error; err != nil {
 		http.Error(w, "Failed to fetch messages", http.StatusInternalServerError)
 		return
 	}
@@ -25,7 +24,7 @@ func handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(messages)
 }
 
-func handleCreateMessage(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleCreateMessage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -41,14 +40,13 @@ func handleCreateMessage(w http.ResponseWriter, r *http.Request) {
 		CreateMessage: req,
 	}
 
-	if err := models.DB.Create(&message).Error; err != nil {
-		// Validation/analysis errors should be returned to the client
+	if err := s.DB.Create(&message).Error; err != nil {
 		log.Printf("Create message failed: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	models.RefreshHashes(models.DB)
+	models.RefreshHashes(s.DB)
 
 	w.WriteHeader(http.StatusCreated)
 }

--- a/src/api/ping.go
+++ b/src/api/ping.go
@@ -9,21 +9,19 @@ import (
 
 type PingResponse struct {
 	Hashes models.HashSet `json:"hash"`
-	IsBusy bool `json:"is_busy"`
+	IsBusy bool           `json:"is_busy"`
 }
 
-func handlePing(w http.ResponseWriter, _ *http.Request) {
-	hashes, err := models.GetDatabaseHashes(models.DB)
+func (s *Server) handlePing(w http.ResponseWriter, _ *http.Request) {
+	hashes, err := models.GetDatabaseHashes(s.DB)
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	isSyncing := models.IsSyncing()
-
 	response := PingResponse{
 		Hashes: hashes,
-		IsBusy: isSyncing,
+		IsBusy: models.IsSyncing(),
 	}
 
 	json.NewEncoder(w).Encode(response)

--- a/src/api/router.go
+++ b/src/api/router.go
@@ -5,7 +5,20 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"gorm.io/gorm"
 )
+
+// Server holds the per-process state the HTTP handlers need — currently
+// just the *gorm.DB. Creating one binds the routes to a specific DB, so
+// tests can spin up an in-memory SQLite and exercise handlers directly.
+type Server struct {
+	DB *gorm.DB
+}
+
+func NewServer(db *gorm.DB) *Server {
+	return &Server{DB: db}
+}
 
 type spaFileSystem struct {
 	root    http.FileSystem
@@ -15,39 +28,35 @@ type spaFileSystem struct {
 func (fs *spaFileSystem) Open(name string) (http.File, error) {
 	log.Printf("Attempting to serve: %s", name)
 
-	// Don't interfere with API routes
 	if strings.HasPrefix(name, "/v1/") {
 		return nil, os.ErrNotExist
 	}
 
 	f, err := fs.root.Open(name)
 	if os.IsNotExist(err) {
-		// Serve index.html for any path that doesn't exist
 		return fs.root.Open("index.html")
 	}
 	return f, err
 }
 
-func RegisterRoutes() {
-	// Log current working directory
+func (s *Server) RegisterRoutes() {
 	cwd, _ := os.Getwd()
 	log.Printf("Current working directory: %s", cwd)
 
-	// Serve frontend files with SPA support
 	fs := &spaFileSystem{root: http.Dir("frontend/dist"), indexes: true}
 	http.Handle("/", http.FileServer(fs))
 
-	http.HandleFunc("/v1/ping", handlePing)
-	http.HandleFunc("/v1/sync", handleSync)
-	http.HandleFunc("/v1/sync/messages", handleSyncMessages)
-	http.HandleFunc("/v1/sync/bulletins", handleSyncBulletins)
-	http.HandleFunc("/v1/sync/users", handleSyncUsers)
+	http.HandleFunc("/v1/ping", s.handlePing)
+	http.HandleFunc("/v1/sync", s.handleSync)
+	http.HandleFunc("/v1/sync/messages", s.handleSyncMessages)
+	http.HandleFunc("/v1/sync/bulletins", s.handleSyncBulletins)
+	http.HandleFunc("/v1/sync/users", s.handleSyncUsers)
 
 	// User routes
 	http.HandleFunc("/v1/users/search", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Users search endpoint: %s %s", r.Method, r.URL.Path)
 		if r.Method == http.MethodGet {
-			handleSearchUsers(w, r)
+			s.handleSearchUsers(w, r)
 		} else {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -56,7 +65,7 @@ func RegisterRoutes() {
 	http.HandleFunc("/v1/users/recent", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Users recent endpoint: %s %s", r.Method, r.URL.Path)
 		if r.Method == http.MethodGet {
-			handleRecentUsers(w, r)
+			s.handleRecentUsers(w, r)
 		} else {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -65,7 +74,7 @@ func RegisterRoutes() {
 	http.HandleFunc("/v1/users/{fingerprint}", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("User endpoint: %s %s", r.Method, r.URL.Path)
 		if r.Method == http.MethodGet {
-			handleGetUser(w, r)
+			s.handleGetUser(w, r)
 		} else {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -75,9 +84,9 @@ func RegisterRoutes() {
 		log.Printf("Users endpoint: %s %s", r.Method, r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
-			handleGetUsers(w, r)
+			s.handleGetUsers(w, r)
 		case http.MethodPost:
-			handleRegisterUser(w, r)
+			s.handleRegisterUser(w, r)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -88,9 +97,9 @@ func RegisterRoutes() {
 		log.Printf("Messages endpoint: %s %s", r.Method, r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
-			handleGetMessages(w, r)
+			s.handleGetMessages(w, r)
 		case http.MethodPost:
-			handleCreateMessage(w, r)
+			s.handleCreateMessage(w, r)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -101,9 +110,9 @@ func RegisterRoutes() {
 		log.Printf("Bulletin endpoint: %s %s", r.Method, r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
-			handleGetBulletin(w, r)
+			s.handleGetBulletin(w, r)
 		case http.MethodPost:
-			handleCreateBulletin(w, r)
+			s.handleCreateBulletin(w, r)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}

--- a/src/api/server_test.go
+++ b/src/api/server_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"axial/models"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newTestServer spins up an in-memory SQLite DB and binds an api.Server to
+// it. The smoke test below proves the DB seam — handlers can be exercised
+// without Postgres, network sockets, or a multicast listener.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite memory DB: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Message{}, &models.Bulletin{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewServer(db)
+}
+
+func TestServer_HandleGetUsers_EmptyDB(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/users", nil)
+	rr := httptest.NewRecorder()
+	s.handleGetUsers(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	var got []models.User
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v (body=%q)", err, rr.Body.String())
+	}
+	if len(got) != 0 {
+		t.Errorf("empty DB should return zero users, got %d", len(got))
+	}
+}
+
+func TestServer_HandlePing_RefreshesHashesOnEmptyDB(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/ping", nil)
+	rr := httptest.NewRecorder()
+	s.handlePing(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	var got PingResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v (body=%q)", err, rr.Body.String())
+	}
+	if got.Hashes.Full == "" {
+		t.Error("expected non-empty Full hash even for empty DB (sha256 of empty input)")
+	}
+}

--- a/src/api/sync.go
+++ b/src/api/sync.go
@@ -32,8 +32,7 @@ type SyncResponse struct {
 	Users           []models.UsersRange       `json:"users,omitempty"`
 }
 
-func handleSync(w http.ResponseWriter, r *http.Request) {
-	// Check if we're busy
+func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
 	if models.IsSyncing() {
 		json.NewEncoder(w).Encode(SyncResponse{
 			IsBusy: true,
@@ -42,13 +41,13 @@ func handleSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == http.MethodPost {
-		handleSyncRequest(w, r)
+		s.handleSyncRequest(w, r)
 	} else {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
-func handleSyncRequest(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSyncRequest(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("Handling sync request...\n")
 	if !models.StartSync() {
 		fmt.Printf("Sync already in progress, returning busy response\n")
@@ -65,7 +64,7 @@ func handleSyncRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid request", http.StatusBadRequest)
 		return
 	}
-	resp, err := ComputeSyncResponse(models.DB, req)
+	resp, err := ComputeSyncResponse(s.DB, req)
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return

--- a/src/api/sync_bulletins.go
+++ b/src/api/sync_bulletins.go
@@ -1,16 +1,17 @@
 package api
 
 import (
-	"axial/models"
 	"encoding/json"
 	"net/http"
+
+	"axial/models"
 )
 
 type SyncBulletinsRequest struct {
 	Bulletins []models.Bulletin `json:"messages"`
 }
 
-func handleSyncBulletins(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSyncBulletins(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -22,16 +23,13 @@ func handleSyncBulletins(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
 	if len(req.Bulletins) == 0 {
 		http.Error(w, "Bulletins are required", http.StatusBadRequest)
 		return
 	}
 
-	// Create bulletins
 	for _, bulletin := range req.Bulletins {
-		if err := models.DB.Create(&bulletin).Error; err != nil {
-			// Ignore duplicate errors
+		if err := s.DB.Create(&bulletin).Error; err != nil {
 			if models.IsDuplicateError(err) {
 				continue
 			}
@@ -40,8 +38,7 @@ func handleSyncBulletins(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	models.RefreshHashes(models.DB)
+	models.RefreshHashes(s.DB)
 
 	w.WriteHeader(http.StatusCreated)
-
 }

--- a/src/api/sync_messages.go
+++ b/src/api/sync_messages.go
@@ -1,16 +1,17 @@
 package api
 
 import (
-	"axial/models"
 	"encoding/json"
 	"net/http"
+
+	"axial/models"
 )
 
 type SyncMessagesRequest struct {
 	Messages []models.Message `json:"messages"`
 }
 
-func handleSyncMessages(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSyncMessages(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -22,16 +23,13 @@ func handleSyncMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
 	if len(req.Messages) == 0 {
 		http.Error(w, "Messages are required", http.StatusBadRequest)
 		return
 	}
 
-	// Create messages
 	for _, message := range req.Messages {
-		if err := models.DB.Create(&message).Error; err != nil {
-			// Ignore duplicate errors
+		if err := s.DB.Create(&message).Error; err != nil {
 			if models.IsDuplicateError(err) {
 				continue
 			}
@@ -40,8 +38,7 @@ func handleSyncMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	models.RefreshHashes(models.DB)
+	models.RefreshHashes(s.DB)
 
 	w.WriteHeader(http.StatusCreated)
-
 }

--- a/src/api/sync_users.go
+++ b/src/api/sync_users.go
@@ -1,16 +1,17 @@
 package api
 
 import (
-	"axial/models"
 	"encoding/json"
 	"net/http"
+
+	"axial/models"
 )
 
 type SyncUsersRequest struct {
 	Users []models.User `json:"users"`
 }
 
-func handleSyncUsers(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSyncUsers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -22,16 +23,13 @@ func handleSyncUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
 	if len(req.Users) == 0 {
 		http.Error(w, "Users are required", http.StatusBadRequest)
 		return
 	}
 
-	// Create users
 	for _, user := range req.Users {
-		if err := models.DB.Create(&user).Error; err != nil {
-			// Ignore duplicate errors
+		if err := s.DB.Create(&user).Error; err != nil {
 			if models.IsDuplicateError(err) {
 				continue
 			}
@@ -40,8 +38,7 @@ func handleSyncUsers(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	models.RefreshHashes(models.DB)
+	models.RefreshHashes(s.DB)
 
 	w.WriteHeader(http.StatusCreated)
-
 }

--- a/src/api/users.go
+++ b/src/api/users.go
@@ -15,14 +15,14 @@ type UserRegistration struct {
 	PublicKey   string `json:"public_key"`
 }
 
-func handleGetUsers(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	var users []models.User
-	if err := models.DB.Find(&users).Error; err != nil {
+	if err := s.DB.Find(&users).Error; err != nil {
 		http.Error(w, "Failed to fetch users", http.StatusInternalServerError)
 		return
 	}
@@ -31,7 +31,7 @@ func handleGetUsers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(users)
 }
 
-func handleGetUser(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -44,7 +44,7 @@ func handleGetUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var user models.User
-	if err := models.DB.Where("fingerprint = ?", fingerprint).First(&user).Error; err != nil {
+	if err := s.DB.Where("fingerprint = ?", fingerprint).First(&user).Error; err != nil {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
 	}
@@ -53,7 +53,7 @@ func handleGetUser(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(user)
 }
 
-func handleRegisterUser(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleRegisterUser(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -71,18 +71,18 @@ func handleRegisterUser(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	if err := models.DB.Create(&user).Error; err != nil {
+	if err := s.DB.Create(&user).Error; err != nil {
 		http.Error(w, "Failed to register user", http.StatusInternalServerError)
 		return
 	}
 
-	models.RefreshHashes(models.DB)
+	models.RefreshHashes(s.DB)
 
 	w.WriteHeader(http.StatusCreated)
 } 
 
 // GET /v1/users/search?q=...&limit=20&offset=0
-func handleSearchUsers(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSearchUsers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -127,13 +127,13 @@ func handleSearchUsers(w http.ResponseWriter, r *http.Request) {
 	var users []models.User
 	var total int64
 	// Fingerprint substring match (case-insensitive)
-	if err := models.DB.Model(&models.User{}).
+	if err := s.DB.Model(&models.User{}).
 		Where("fingerprint ILIKE ?", "%"+q+"%").
 		Count(&total).Error; err != nil {
 		http.Error(w, "Failed to count users", http.StatusInternalServerError)
 		return
 	}
-	if err := models.DB.
+	if err := s.DB.
 		Where("fingerprint ILIKE ?", "%"+q+"%").
 		Order("fingerprint ASC").
 		Limit(limit).Offset(offset).
@@ -154,7 +154,7 @@ func handleSearchUsers(w http.ResponseWriter, r *http.Request) {
 
 // GET /v1/users/recent?limit=10
 // Derive distinct counterpart fingerprints from messages involving the current user.
-func handleRecentUsers(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleRecentUsers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -177,7 +177,7 @@ func handleRecentUsers(w http.ResponseWriter, r *http.Request) {
 	// Fetch messages where the user is sender or among recipients (JSONB array contains)
 	var messages []models.Message
 	arrayContains := fmt.Sprintf("[\"%s\"]", current)
-	if err := models.DB.
+	if err := s.DB.
 		Where("sender = ?", current).
 		Or("to_jsonb(recipients)::jsonb @> ?", arrayContains).
 		Order("created_at DESC").
@@ -228,7 +228,7 @@ func handleRecentUsers(w http.ResponseWriter, r *http.Request) {
 	for _, p := range pairs { fps = append(fps, p.fp) }
 	var users []models.User
 	if len(fps) > 0 {
-		if err := models.DB.Where("fingerprint IN ?", fps).Find(&users).Error; err != nil {
+		if err := s.DB.Where("fingerprint IN ?", fps).Find(&users).Error; err != nil {
 			http.Error(w, "Failed to fetch users", http.StatusInternalServerError)
 			return
 		}

--- a/src/discovery/multicast.go
+++ b/src/discovery/multicast.go
@@ -13,6 +13,8 @@ import (
 	"axial/models"
 	"axial/remote"
 	"axial/synchronization"
+
+	"gorm.io/gorm"
 )
 
 // New type to hold our connections
@@ -241,7 +243,7 @@ func setupMulticastConn(cfg config.Config, iface *net.Interface, addr *net.UDPAd
 	return conn, nil
 }
 
-func StartMulticastListener(cfg config.Config, conn *MulticastConnection) {
+func StartMulticastListener(cfg config.Config, conn *MulticastConnection, db *gorm.DB) {
 	fmt.Printf("Listening for messages on %v\n", conn.Conn.LocalAddr())
 	buffer := make([]byte, 4096)
 
@@ -283,7 +285,7 @@ func StartMulticastListener(cfg config.Config, conn *MulticastConnection) {
 						Address: fmt.Sprintf("%s%s", src.IP, port),
 					}
 					
-					err := synchronization.StartSync(remoteNode, hash)
+					err := synchronization.StartSync(db, remoteNode, hash)
 					if err != nil {
 						fmt.Printf("Failed to start sync: %v\n", err)
 					} else {

--- a/src/main.go
+++ b/src/main.go
@@ -20,29 +20,23 @@ func main() {
 
 	nodeID := cfg.NodeID
 	if nodeID == "" {
-		// Default to hostname
 		nodeID, _ = os.Hostname()
 	}
 
-	// Initialize database connection
-	err = models.InitDB(cfg.Database)
+	db, err := models.InitDB(cfg.Database)
 	if err != nil {
 		panic(fmt.Errorf("failed to initialize database: %v", err))
 	}
 
 	fmt.Printf("Starting node %s\n", nodeID)
 
-	// Calculate initial hash
-	err = models.RefreshHashes(models.DB)
-	if err != nil {
+	if err := models.RefreshHashes(db); err != nil {
 		panic(fmt.Errorf("failed to calculate database hash: %v", err))
 	}
 
 	hashes := models.GetHashes()
-
 	fmt.Printf("Node %s hash: %s\n", nodeID, hashes.Full)
 
-	// Create single multicast socket
 	connections, err := discovery.CreateMulticastSockets(cfg)
 	if err != nil {
 		panic(err)
@@ -50,14 +44,12 @@ func main() {
 
 	for _, conn := range connections {
 		defer conn.Conn.Close()
-		go discovery.StartMulticastListener(cfg, &conn)
+		go discovery.StartMulticastListener(cfg, &conn, db)
 		go discovery.StartBroadcast(cfg, &conn)
 	}
 
-	// Register API routes
-	api.RegisterRoutes()
+	api.NewServer(db).RegisterRoutes()
 
-	// Start server
 	port := 8080
 	fmt.Printf("Server starting on port %d...\n", port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {

--- a/src/models/database.go
+++ b/src/models/database.go
@@ -13,44 +13,40 @@ import (
 	"axial/config"
 )
 
-var DB *gorm.DB
-
 const (
 	UniqueViolationErr = "23505"
 )
 
-// InitDB establishes a connection to the database and performs migrations
-func InitDB(cfg config.DatabaseConfig) error {
+// InitDB connects to PostgreSQL, runs migrations, and returns the resulting
+// *gorm.DB. The caller is responsible for holding the handle and passing it
+// to the modules that need it — there is no package-level global.
+func InitDB(cfg config.DatabaseConfig) (*gorm.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
 		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name)
 
-	// Enable detailed logging for migrations
 	gormConfig := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Info),
 	}
 
-	var err error
-	DB, err = gorm.Open(postgres.Open(dsn), gormConfig)
+	db, err := gorm.Open(postgres.Open(dsn), gormConfig)
 	if err != nil {
-		return fmt.Errorf("failed to connect to database: %v", err)
+		return nil, fmt.Errorf("failed to connect to database: %v", err)
 	}
 
 	log.Println("Running migrations...")
-	// Run migrations
-	if err := DB.AutoMigrate(&User{}, &Message{}, &Bulletin{}); err != nil {
-		return fmt.Errorf("failed to run migrations: %v", err)
+	if err := db.AutoMigrate(&User{}, &Message{}, &Bulletin{}); err != nil {
+		return nil, fmt.Errorf("failed to run migrations: %v", err)
 	}
 
-	// Debug: Print table schema
 	var tableInfo []struct {
 		ColumnName string `gorm:"column:column_name"`
 		DataType   string `gorm:"column:data_type"`
 		IsNullable string `gorm:"column:is_nullable"`
 	}
 
-	if err := DB.Raw(`
-		SELECT column_name, data_type, is_nullable 
-		FROM information_schema.columns 
+	if err := db.Raw(`
+		SELECT column_name, data_type, is_nullable
+		FROM information_schema.columns
 		WHERE table_name = 'bulletin_board'
 		ORDER BY ordinal_position
 	`).Scan(&tableInfo).Error; err != nil {
@@ -62,15 +58,7 @@ func InitDB(cfg config.DatabaseConfig) error {
 		}
 	}
 
-	return nil
-}
-
-func GetUserByFingerprint(fingerprint Fingerprint) (*User, error) {
-	var user User
-	if err := DB.Where("fingerprint = ?", fingerprint).First(&user).Error; err != nil {
-		return nil, err
-	}
-	return &user, nil
+	return db, nil
 }
 
 func IsDuplicateError(err error) bool {

--- a/src/synchronization/sync_integration_test.go
+++ b/src/synchronization/sync_integration_test.go
@@ -175,7 +175,6 @@ func TestFullSyncConverges(t *testing.T) {
     nodeB := remote.API{Address: "nodeB"}
 
     // Round 1: A syncs with B
-    models.DB = dbA.Session(&gorm.Session{SkipHooks: true})
     missingForBFromA, err := SyncWithRequester(inMemoryRequester{DB: dbB}, nodeB, hashedA, nil)
     if err != nil { t.Fatalf("sync A->B: %v", err) }
     // Apply to B
@@ -186,7 +185,6 @@ func TestFullSyncConverges(t *testing.T) {
     }
 
     // Round 2: B syncs with A
-    models.DB = dbB.Session(&gorm.Session{SkipHooks: true})
     missingForAFromB, err := SyncWithRequester(inMemoryRequester{DB: dbA}, nodeA, hashedB, nil)
     if err != nil { t.Fatalf("sync B->A: %v", err) }
     // Apply to A
@@ -197,12 +195,9 @@ func TestFullSyncConverges(t *testing.T) {
     }
 
     // Optional extra round to ensure convergence if splits occurred
-    models.DB = dbA.Session(&gorm.Session{SkipHooks: true})
     hashedA2, _ := models.GenerateHashRanges(dbA, periods)
-    models.DB = dbB.Session(&gorm.Session{SkipHooks: true})
     hashedB2, _ := models.GenerateHashRanges(dbB, periods)
 
-    models.DB = dbA.Session(&gorm.Session{SkipHooks: true})
     moreForB, err := SyncWithRequester(inMemoryRequester{DB: dbB}, nodeB, hashedA2, nil)
     if err != nil { t.Fatalf("sync A->B (2): %v", err) }
     for _, m := range moreForB {
@@ -211,7 +206,6 @@ func TestFullSyncConverges(t *testing.T) {
         }
     }
 
-    models.DB = dbB.Session(&gorm.Session{SkipHooks: true})
     moreForA, err := SyncWithRequester(inMemoryRequester{DB: dbA}, nodeA, hashedB2, nil)
     if err != nil { t.Fatalf("sync B->A (2): %v", err) }
     for _, m := range moreForA {

--- a/src/synchronization/sync_process.go
+++ b/src/synchronization/sync_process.go
@@ -11,6 +11,8 @@ import (
 	"axial/api"
 	"axial/models"
 	"axial/remote"
+
+	"gorm.io/gorm"
 )
 
 // SyncRequester abstracts how a sync request is sent to a remote node.
@@ -53,8 +55,8 @@ func (h httpSyncRequester) httpPost(node remote.API, jsonRequest []byte) (*http.
 	return client.Post(fmt.Sprintf("http://%s/v1/sync", node.Address), "application/json", bytes.NewBuffer(jsonRequest))
 }
 
-func StartSync(node remote.API, hash string) error {
-	hashes, err := models.GetDatabaseHashes(models.DB)
+func StartSync(db *gorm.DB, node remote.API, hash string) error {
+	hashes, err := models.GetDatabaseHashes(db)
 	if err != nil {
 		return err
 	}
@@ -69,25 +71,24 @@ func StartSync(node remote.API, hash string) error {
 	defer models.EndSync()
 
 	periods, stringRanges := startingSyncRanges()
-	hashedMessagesPeriods, err := models.GetMessagesHashRanges(models.DB, periods)
+	hashedMessagesPeriods, err := models.GetMessagesHashRanges(db, periods)
 	if err != nil {
 		return err
 	}
 
-	hashedBulletinsPeriods, err := models.GetBulletinsHashRanges(models.DB, periods)
+	hashedBulletinsPeriods, err := models.GetBulletinsHashRanges(db, periods)
 	if err != nil {
 		return err
 	}
 
-	hashedUsers, err := models.GetUsersHashRanges(models.DB, stringRanges)
+	hashedUsers, err := models.GetUsersHashRanges(db, stringRanges)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Synchronizing with %s\n", node.Address)
 
-	// Use HTTP requester by default in production flows.
-	messages, bulletins, users, err := Sync(node, hashedMessagesPeriods, hashedBulletinsPeriods, hashedUsers)
+	messages, bulletins, users, err := Sync(db, node, hashedMessagesPeriods, hashedBulletinsPeriods, hashedUsers)
 	if err != nil {
 		return err
 	}
@@ -133,13 +134,13 @@ func SortBulletins(bulletins []models.Bulletin) {
 //
 // For unit tests, prefer calling SyncWithRequester with a custom requester that
 // uses in-memory handlers to return api.SyncResponse.
-func Sync(node remote.API, hashedMessagePeriods []models.HashedPeriod, hashedBulletinPeriods []models.HashedPeriod, hashedUsers []models.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
-	return SyncWithRequester(httpSyncRequester{}, node, hashedMessagePeriods, hashedBulletinPeriods, hashedUsers)
+func Sync(db *gorm.DB, node remote.API, hashedMessagePeriods []models.HashedPeriod, hashedBulletinPeriods []models.HashedPeriod, hashedUsers []models.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
+	return SyncWithRequester(db, httpSyncRequester{}, node, hashedMessagePeriods, hashedBulletinPeriods, hashedUsers)
 }
 
 // SyncWithRequester is identical to Sync but allows the caller to provide a
 // pluggable requester for testability.
-func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesPeriods []models.HashedPeriod, hashedBulletinPeriods []models.HashedPeriod, hashedUsers []models.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
+func SyncWithRequester(db *gorm.DB, requester SyncRequester, node remote.API, hashedMessagesPeriods []models.HashedPeriod, hashedBulletinPeriods []models.HashedPeriod, hashedUsers []models.HashedUsersRange) ([]models.Message, []models.Bulletin, []models.User, error) {
 	if len(hashedMessagesPeriods) == 0 {
 		fmt.Printf("No periods to sync with %s\n", node.Address)
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, nil
@@ -169,7 +170,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 	messagesMissingInRemote := []models.Message{}
 
 	for _, messagesPeriod := range syncResponse.Messages {
-		ourMessages, err := models.GetMessagesByPeriod(models.DB, messagesPeriod.Period)
+		ourMessages, err := models.GetMessagesByPeriod(db, messagesPeriod.Period)
 		if err != nil {
 			return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to get messages by period: %v", err)
 		}
@@ -178,7 +179,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 			if !message.In(ourMessages) {
 				fmt.Printf("Inserting message into our database: %+v\n", message)
 				// Insert message into our database
-				if err := models.DB.Create(&message).Error; err != nil {
+				if err := db.Create(&message).Error; err != nil {
 					// Ignore duplicate key errors since those messages were already synced
 					if !strings.Contains(err.Error(), "duplicate key") {
 						return []models.Message{}, []models.Bulletin{}, []models.User{}, err
@@ -199,7 +200,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		periodsForRemoteMessagesHashes = append(periodsForRemoteMessagesHashes, hashedPeriod.Period)
 	}
 
-	ourMessagesHashes, err := models.GetMessagesHashRanges(models.DB, periodsForRemoteMessagesHashes)
+	ourMessagesHashes, err := models.GetMessagesHashRanges(db, periodsForRemoteMessagesHashes)
 	if err != nil {
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to generate hash ranges: %v", err)
 	}
@@ -210,7 +211,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 	bulletinsMissingInRemote := []models.Bulletin{}
 
 	for _, bulletinPeriod := range syncResponse.Bulletins {
-		ourBulletins, err := models.GetBulletinsByPeriod(models.DB, bulletinPeriod.Period)
+		ourBulletins, err := models.GetBulletinsByPeriod(db, bulletinPeriod.Period)
 		if err != nil {
 			return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to get bulletins by period: %v", err)
 		}
@@ -219,7 +220,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 			if !bulletin.In(ourBulletins) {
 				fmt.Printf("Inserting bulletin into our database: %+v\n", bulletin)
 				// Insert bulletin into our database
-				if err := models.DB.Create(&bulletin).Error; err != nil {
+				if err := db.Create(&bulletin).Error; err != nil {
 					// Ignore duplicate key errors since those bulletins were already synced
 					if !strings.Contains(err.Error(), "duplicate key") {
 						return []models.Message{}, []models.Bulletin{}, []models.User{}, err
@@ -240,7 +241,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 		periodsForRemoteBulletinHashes = append(periodsForRemoteBulletinHashes, hashedPeriod.Period)
 	}
 
-	ourBulletinHashes, err := models.GetBulletinsHashRanges(models.DB, periodsForRemoteBulletinHashes)
+	ourBulletinHashes, err := models.GetBulletinsHashRanges(db, periodsForRemoteBulletinHashes)
 	if err != nil {
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to generate bulletin hash ranges: %v", err)
 	}
@@ -252,7 +253,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 
 	// Ingest users returned by the remote for mismatching ranges
 	for _, usersRange := range syncResponse.Users {
-		ourUsers, err := models.GetUsersByFingerprintRange(models.DB, usersRange.StringRange.Start, usersRange.StringRange.End)
+		ourUsers, err := models.GetUsersByFingerprintRange(db, usersRange.StringRange.Start, usersRange.StringRange.End)
 		if err != nil {
 			return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to get users by fingerprint range: %v", err)
 		}
@@ -268,7 +269,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 			}
 			if !found {
 				fmt.Printf("Inserting user into our database: %+v\n", user)
-				if err := models.DB.Create(&user).Error; err != nil {
+				if err := db.Create(&user).Error; err != nil {
 					if !strings.Contains(err.Error(), "duplicate key") {
 						return []models.Message{}, []models.Bulletin{}, []models.User{}, err
 					}
@@ -294,7 +295,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 	userRangesToCheck := []models.HashedUsersRange{}
 
 	for _, hashedUserRange := range syncResponse.UserRangeHashes {
-		ourUserHash, err := models.GetUsersHashByFingerprintRange(models.DB, hashedUserRange.Start, hashedUserRange.End)
+		ourUserHash, err := models.GetUsersHashByFingerprintRange(db, hashedUserRange.Start, hashedUserRange.End)
 		if err != nil {
 			return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to get users by fingerprint range: %v", err)
 		}
@@ -305,7 +306,7 @@ func SyncWithRequester(requester SyncRequester, node remote.API, hashedMessagesP
 
 	}
 
-	newMessagesMissingInRemote, newBulletinsMissingInRemote, newUsersMissingInRemote, err := SyncWithRequester(requester, node, hashedMessagesPeriodsToCheck, hashedBulletinPeriodsToCheck, userRangesToCheck)
+	newMessagesMissingInRemote, newBulletinsMissingInRemote, newUsersMissingInRemote, err := SyncWithRequester(db, requester, node, hashedMessagesPeriodsToCheck, hashedBulletinPeriodsToCheck, userRangesToCheck)
 	if err != nil {
 		return []models.Message{}, []models.Bulletin{}, []models.User{}, fmt.Errorf("failed to sync new messages missing in remote: %v", err)
 	}

--- a/src/synchronization/sync_process_test.go
+++ b/src/synchronization/sync_process_test.go
@@ -177,8 +177,8 @@ func TestSyncExchangeSkeleton(t *testing.T) {
 	nodeB := remote.API{Address: "nodeB"}
 
 	// Round 1: A pulls from B and computes messages to send to B
-	models.DB = dbA.Session(&gorm.Session{SkipHooks: true})
-	missingMessagesForBFromA, missingBulletinsForBFromA, missingUsersForBFromA, err := SyncWithRequester(fakeRequester{DB: dbB}, nodeB, hashedMessagesA, hashedBulletinsA, hashedUsersA)
+	dbARaw := dbA.Session(&gorm.Session{SkipHooks: true})
+	missingMessagesForBFromA, missingBulletinsForBFromA, missingUsersForBFromA, err := SyncWithRequester(dbARaw, fakeRequester{DB: dbB}, nodeB, hashedMessagesA, hashedBulletinsA, hashedUsersA)
 	if err != nil {
 		t.Fatalf("sync A->B: %v", err)
 	}
@@ -200,8 +200,8 @@ func TestSyncExchangeSkeleton(t *testing.T) {
 	}
 
 	// Round 2: B pulls from A and applies
-	models.DB = dbB.Session(&gorm.Session{SkipHooks: true})
-	missingMessagesForAFromB, missingBulletinsForAFromB, missingUsersForAFromB, err := SyncWithRequester(fakeRequester{DB: dbA}, nodeA, hashedMessagesB, hashedBulletinsB, hashedUsersB)
+	dbBRaw := dbB.Session(&gorm.Session{SkipHooks: true})
+	missingMessagesForAFromB, missingBulletinsForAFromB, missingUsersForAFromB, err := SyncWithRequester(dbBRaw, fakeRequester{DB: dbA}, nodeA, hashedMessagesB, hashedBulletinsB, hashedUsersB)
 	if err != nil {
 		t.Fatalf("sync B->A: %v", err)
 	}


### PR DESCRIPTION
## Summary

The global `var DB *gorm.DB` made every module's interface implicit — api handlers, sync orchestration, hashing, and discovery all reached for `models.DB` directly. That left the api package effectively untestable (no way to bind handlers to an in-memory SQLite without race-hostile global mutation) and tangled the post-write `RefreshHashes(models.DB)` pattern with the global.

This PR injects the DB at every module boundary:

- **`models/database.go`** — `InitDB(cfg) (*gorm.DB, error)` returns the DB; the `var DB` global is gone. Unused `GetUserByFingerprint` (no callers; only existed to wrap the global) is deleted.
- **`api/router.go`** — introduces `api.Server` holding the `*gorm.DB`. Every handler becomes a method on `*Server`; `RegisterRoutes` is a method too. Tests can now bind a Server to an in-memory SQLite.
- **`synchronization/sync_process.go`** — `StartSync(db, ...)`, `Sync(db, ...)`, and `SyncWithRequester(db, ...)` all take `*gorm.DB` as their first parameter. The recursive drill threads `db` through. No more `models.DB` references inside.
- **`discovery/multicast.go`** — `StartMulticastListener(cfg, conn, db)` forwards the DB to `synchronization.StartSync`.
- **`main.go`** — owns the `*gorm.DB`, wires it into the listener, the sync orchestrator, and `api.NewServer`.

## Test surface

- **`api/server_test.go` (new)** — two smoke tests proving the new seam: `TestServer_HandleGetUsers_EmptyDB` and `TestServer_HandlePing_RefreshesHashesOnEmptyDB`. The api package previously had **zero** coverage; this PR establishes that handlers can be unit-tested without Postgres or sockets.
- **`synchronization/sync_process_test.go`** — stops swapping the global (`models.DB = dbA.Session(...)`) and passes the db argument to `SyncWithRequester` directly. Less spooky, no shared state between tests.

`grep -rn 'models\.DB' src/` returns zero hits after this PR (verified locally before commit).

Net: +191 / −153, 16 files. Local `go vet ./...`, `go build ./...`, `go test ./... -race -count=1` all pass.

Closes #23

## Out of scope (preserved verbatim)

- `models.UpdateHashes` still has the pre-existing parameter-vs-package-var bug — out of scope.
- The api package still owns the post-write `RefreshHashes` call pattern. Extracting an ingest module that absorbs it is **task #718** (the original architecture review's natural prerequisite for this task).
- Per-package hash-state globals (the `hashes` var in `hashing_database.go`, the `syncState` mutex in `sync.go`) stay where they are. This task is about DB injection only.
- `synchronization/sync_integration_test.go` is gated by `//go:build integration` and was already broken (calls non-existent `models.GenerateHashRanges`). Only the `models.DB = ...` assignments were stripped, since they refer to a deleted variable.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./... -race -count=1` passes (synchronization + new api smoke tests)
- [x] `grep -rn 'models\.DB' src/` returns no hits
- [ ] CI Go test workflow passes
- [ ] Manual: bring up a multi-node Tilt environment, confirm sync still triggers and a ping still returns the database hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)