### PR TITLE
Extract ingest module behind api/sync_* handlers, fix bulletins JSON tag

### DIFF
--- a/src/api/ingest.go
+++ b/src/api/ingest.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"strings"
+
+	"axial/models"
+
+	"gorm.io/gorm"
+)
+
+// ingest writes a batch of remote-sourced records into the DB on behalf of
+// the sync handlers (Messages, Bulletins, Users). Duplicate-key errors are
+// swallowed on a per-item basis — those records were already synced from
+// another peer. Once the batch is in, the database content hashes are
+// recomputed exactly once so the next multicast broadcast advertises the
+// new Full Hash.
+//
+// The function is the seam between transport (the HTTP handler) and the
+// post-write side effects (insert + RefreshHashes). Tests can call it
+// directly against an in-memory SQLite without spinning up an HTTP server,
+// which is how the per-handler tests exercise the duplicate-suppression
+// and RefreshHashes-on-completion behaviour.
+func ingest[T any](db *gorm.DB, items []T) error {
+	for i := range items {
+		if err := db.Create(&items[i]).Error; err != nil {
+			if isDuplicate(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return models.RefreshHashes(db)
+}
+
+// isDuplicate matches either Postgres' SQLSTATE 23505 (via
+// models.IsDuplicateError) or SQLite's "UNIQUE constraint failed" wording.
+// Sync rounds are eventually-consistent — a duplicate ingest happens
+// whenever the same content arrives from two peers — so absorption must
+// work on both drivers, not just the production one.
+func isDuplicate(err error) bool {
+	if err == nil {
+		return false
+	}
+	if models.IsDuplicateError(err) {
+		return true
+	}
+	return strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/src/api/ingest_test.go
+++ b/src/api/ingest_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"testing"
+
+	"axial/models"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newIngestTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Message{}, &models.Bulletin{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestIngest_EmptyBatchStillRefreshesHashes(t *testing.T) {
+	db := newIngestTestDB(t)
+	if err := ingest[models.User](db, nil); err != nil {
+		t.Fatalf("ingest empty: %v", err)
+	}
+	// RefreshHashes populates the in-process hash cache; reading it back
+	// proves the side effect ran.
+	hs := models.GetHashes()
+	if hs.Full == "" {
+		t.Error("expected Full hash to be set after RefreshHashes, got empty")
+	}
+}
+
+func TestIngest_DuplicateKeysAreSwallowed(t *testing.T) {
+	db := newIngestTestDB(t)
+
+	// Two users with the same fingerprint trip the unique-index. Skipping
+	// hooks lets us bypass the BeforeCreate PGP validation so the test
+	// stays focused on the duplicate-suppression branch.
+	u := models.User{Fingerprint: "fp-dup-test"}
+	u.Base.ID = "fp-dup-test"
+	raw := db.Session(&gorm.Session{SkipHooks: true})
+	if err := raw.Create(&u).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Now ingest the same record again — should not error.
+	if err := ingest[models.User](raw, []models.User{u}); err != nil {
+		t.Errorf("duplicate-key should be swallowed, got %v", err)
+	}
+}
+
+func TestIngest_NonDuplicateErrorsPropagate(t *testing.T) {
+	// Closing the DB session and pointing ingest at it forces a non-duplicate
+	// error to surface; the caller (the handler) must see it as a 500.
+	db := newIngestTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	err = ingest[models.User](db, []models.User{{Fingerprint: "fp"}})
+	if err == nil {
+		t.Error("expected error from ingest into closed DB, got nil")
+	}
+}

--- a/src/api/sync_bulletins.go
+++ b/src/api/sync_bulletins.go
@@ -1,13 +1,14 @@
 package api
 
 import (
-	"axial/models"
 	"encoding/json"
 	"net/http"
+
+	"axial/models"
 )
 
 type SyncBulletinsRequest struct {
-	Bulletins []models.Bulletin `json:"messages"`
+	Bulletins []models.Bulletin `json:"bulletins"`
 }
 
 func handleSyncBulletins(w http.ResponseWriter, r *http.Request) {
@@ -22,26 +23,15 @@ func handleSyncBulletins(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
 	if len(req.Bulletins) == 0 {
 		http.Error(w, "Bulletins are required", http.StatusBadRequest)
 		return
 	}
 
-	// Create bulletins
-	for _, bulletin := range req.Bulletins {
-		if err := models.DB.Create(&bulletin).Error; err != nil {
-			// Ignore duplicate errors
-			if models.IsDuplicateError(err) {
-				continue
-			}
-			http.Error(w, "Failed to create bulletin", http.StatusInternalServerError)
-			return
-		}
+	if err := ingest(models.DB, req.Bulletins); err != nil {
+		http.Error(w, "Failed to ingest bulletins", http.StatusInternalServerError)
+		return
 	}
 
-	models.RefreshHashes(models.DB)
-
 	w.WriteHeader(http.StatusCreated)
-
 }

--- a/src/api/sync_handlers_test.go
+++ b/src/api/sync_handlers_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"axial/models"
+
+	"gorm.io/gorm"
+)
+
+// The handlers currently read from the global models.DB. Tests substitute
+// an in-memory SQLite into the global so they can drive the handlers
+// without Postgres. A package-local mutex is unnecessary because the api
+// package has no other concurrent test surface; if more handler tests
+// arrive they should serialise via t.Setenv-style fixtures.
+func withGlobalDB(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	prev := models.DB
+	models.DB = db
+	t.Cleanup(func() { models.DB = prev })
+}
+
+func TestHandleSyncMessages_RejectsGET(t *testing.T) {
+	withGlobalDB(t, newIngestTestDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/v1/sync/messages", nil)
+	rr := httptest.NewRecorder()
+	handleSyncMessages(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET should be 405, got %d", rr.Code)
+	}
+}
+
+func TestHandleSyncMessages_RejectsEmptyBatch(t *testing.T) {
+	withGlobalDB(t, newIngestTestDB(t))
+	req := httptest.NewRequest(http.MethodPost, "/v1/sync/messages",
+		strings.NewReader(`{"messages": []}`))
+	rr := httptest.NewRecorder()
+	handleSyncMessages(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("empty batch should be 400, got %d", rr.Code)
+	}
+}
+
+func TestHandleSyncMessages_RejectsInvalidJSON(t *testing.T) {
+	withGlobalDB(t, newIngestTestDB(t))
+	req := httptest.NewRequest(http.MethodPost, "/v1/sync/messages",
+		bytes.NewBufferString(`{not json`))
+	rr := httptest.NewRecorder()
+	handleSyncMessages(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("malformed JSON should be 400, got %d", rr.Code)
+	}
+}
+
+// Regression test for the original `json:"messages"` typo on the Bulletins
+// field. Posting a body keyed by "bulletins" must decode into the request
+// struct; if the tag drifts back to "messages" this test goes red.
+func TestHandleSyncBulletins_AcceptsBulletinsKey(t *testing.T) {
+	withGlobalDB(t, newIngestTestDB(t))
+
+	// An empty bulletins array decodes successfully but trips the length
+	// check, so we get a 400 (not 200/201). That's still proof the JSON tag
+	// matched — if the tag were wrong the field would be zero-length under
+	// any key and we'd hit the same 400 path. So we need a non-empty array
+	// to distinguish: with the correct tag we proceed past length check.
+	body := strings.NewReader(`{"bulletins": [{"id":"b1"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sync/bulletins", body)
+	rr := httptest.NewRecorder()
+	handleSyncBulletins(rr, req)
+
+	// We expect either 201 (ingest succeeded) or 500 (ingest failed
+	// downstream — e.g. PGP validation on the empty record). What we MUST
+	// NOT see is 400 "Bulletins are required", which is the symptom of the
+	// JSON tag bug: a wrong tag silently maps `bulletins` to nothing.
+	if rr.Code == http.StatusBadRequest && strings.Contains(rr.Body.String(), "required") {
+		t.Errorf("got %d %q — JSON tag bug regression: 'bulletins' key did not decode into Bulletins field",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// Same shape for Users to lock in the convention.
+func TestHandleSyncUsers_AcceptsUsersKey(t *testing.T) {
+	withGlobalDB(t, newIngestTestDB(t))
+	body := strings.NewReader(`{"users": [{"fingerprint":"u1"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sync/users", body)
+	rr := httptest.NewRecorder()
+	handleSyncUsers(rr, req)
+	if rr.Code == http.StatusBadRequest && strings.Contains(rr.Body.String(), "required") {
+		t.Errorf("got %d %q — `users` key did not decode into Users field",
+			rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleSyncMessages_AcceptsMessagesKey(t *testing.T) {
+	withGlobalDB(t, newIngestTestDB(t))
+	body := strings.NewReader(`{"messages": [{"id":"m1"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sync/messages", body)
+	rr := httptest.NewRecorder()
+	handleSyncMessages(rr, req)
+	if rr.Code == http.StatusBadRequest && strings.Contains(rr.Body.String(), "required") {
+		t.Errorf("got %d %q — `messages` key did not decode into Messages field",
+			rr.Code, rr.Body.String())
+	}
+}

--- a/src/api/sync_messages.go
+++ b/src/api/sync_messages.go
@@ -1,9 +1,10 @@
 package api
 
 import (
-	"axial/models"
 	"encoding/json"
 	"net/http"
+
+	"axial/models"
 )
 
 type SyncMessagesRequest struct {
@@ -22,26 +23,15 @@ func handleSyncMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
 	if len(req.Messages) == 0 {
 		http.Error(w, "Messages are required", http.StatusBadRequest)
 		return
 	}
 
-	// Create messages
-	for _, message := range req.Messages {
-		if err := models.DB.Create(&message).Error; err != nil {
-			// Ignore duplicate errors
-			if models.IsDuplicateError(err) {
-				continue
-			}
-			http.Error(w, "Failed to create message", http.StatusInternalServerError)
-			return
-		}
+	if err := ingest(models.DB, req.Messages); err != nil {
+		http.Error(w, "Failed to ingest messages", http.StatusInternalServerError)
+		return
 	}
 
-	models.RefreshHashes(models.DB)
-
 	w.WriteHeader(http.StatusCreated)
-
 }

--- a/src/api/sync_users.go
+++ b/src/api/sync_users.go
@@ -1,9 +1,10 @@
 package api
 
 import (
-	"axial/models"
 	"encoding/json"
 	"net/http"
+
+	"axial/models"
 )
 
 type SyncUsersRequest struct {
@@ -22,26 +23,15 @@ func handleSyncUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate required fields
 	if len(req.Users) == 0 {
 		http.Error(w, "Users are required", http.StatusBadRequest)
 		return
 	}
 
-	// Create users
-	for _, user := range req.Users {
-		if err := models.DB.Create(&user).Error; err != nil {
-			// Ignore duplicate errors
-			if models.IsDuplicateError(err) {
-				continue
-			}
-			http.Error(w, "Failed to create user", http.StatusInternalServerError)
-			return
-		}
+	if err := ingest(models.DB, req.Users); err != nil {
+		http.Error(w, "Failed to ingest users", http.StatusInternalServerError)
+		return
 	}
 
-	models.RefreshHashes(models.DB)
-
 	w.WriteHeader(http.StatusCreated)
-
 }


### PR DESCRIPTION
## Summary

The three sync handlers ran the same inline script: method-check → JSON decode → length-validate → loop `db.Create` with duplicate-error suppression → `models.RefreshHashes(models.DB)` → 201. Zero tests in `src/api/`, and a real bug had been hiding behind that gap: **`sync_bulletins.go:10` declared the Bulletins field with `json:"messages"`**, so the route silently rejected the documented `"bulletins"` JSON key.

- **New** `src/api/ingest.go` — generic `ingest[T]` function: per-item `Create` with duplicate-key suppression, followed by exactly one `RefreshHashes`. The seam between transport (HTTP handler) and the post-write side effects. Adding a fourth resource type (Files, hinted in FUTURE.md) stops requiring another copy-paste.
- **New helper** `isDuplicate()` recognises both Postgres' SQLSTATE 23505 *and* SQLite's `"UNIQUE constraint failed"` wording. This fixes a latent bug surfaced while writing the test: the old code's duplicate-suppression only worked on Postgres, so duplicate ingests on SQLite-backed tests would have errored. Sync is eventually-consistent — peer-driven duplicate ingests are routine — and absorption must work on both drivers.
- **Three handlers** rewritten as transport-only: decode, length-check, delegate to `ingest`, respond. `RefreshHashes` errors now propagate as 500s instead of being silently swallowed.
- **JSON-tag bug** fixed: `sync_bulletins.go` now reads `json:"bulletins"`.
- **9 new tests** in `api/ingest_test.go` (3) and `api/sync_handlers_test.go` (6). The bulletins-key regression test would have caught the original bug and would catch it again if the tag drifts back.

Net: 6 files, +247 / −49. `src/api/` previously had **zero tests**; this PR adds **9** that exercise transport-decoding, validation, duplicate-suppression, and the hash-refresh side effect.

Closes #22

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./... -race -count=1` passes (9 new api tests + existing synchronization tests)
- [x] Manual reasoning: if the `json:"messages"` typo is reintroduced, `TestHandleSyncBulletins_AcceptsBulletinsKey` goes red
- [ ] CI Go test workflow passes
- [ ] Manual: bring up a multi-node Tilt environment, confirm a bulletin POST still flows through

## Out of scope (intentionally)

- The handlers still read `models.DB` (the global). The DB-injection refactor is task #719 and lives in a separate PR.
- The post-write `RefreshHashes` side effect now belongs to `ingest`, but the *non-sync* handlers (`handleRegisterUser`, `handleCreateMessage`, `handleCreateBulletin`) still call `RefreshHashes` inline. Extending `ingest` to cover them is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)