### PR TITLE
Cleanup: delete dead hashing files in src/models/

### DIFF
--- a/src/models/hashing_common.go
+++ b/src/models/hashing_common.go
@@ -1,7 +1,0 @@
-package models
-
-type HashSource []string
-
-func (hs HashSource) Hash() string {
-	return ""
-}

--- a/src/models/hashing_models.go.go
+++ b/src/models/hashing_models.go.go
@@ -1,2 +1,0 @@
-package models
-


### PR DESCRIPTION
## Summary

Two files in `src/models/` were noise:

- **`hashing_models.go.go`** — 16-byte file containing only `package models\n`. The doubled `.go.go` extension is almost certainly an editor accident from a long-forgotten rename.
- **`hashing_common.go`** — declared `type HashSource []string` with a `Hash() string` method returning `""`. Zero callers anywhere in `src/` (verified via `grep -rn HashSource src/ --include='*.go'` before deletion). Looks like a refactor stub that was abandoned mid-flight.

Both pass the deletion test cleanly.

Closes #20

## Test plan

- [x] `grep -rn HashSource src/` returns only the to-be-deleted file
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./... -race -count=1` passes
- [ ] CI Go test workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)